### PR TITLE
perf(DEE-40): chain.stream → chain.astream in agentic streaming gener…

### DIFF
--- a/core/pipeline_langgraph.py
+++ b/core/pipeline_langgraph.py
@@ -5,6 +5,7 @@ This replaces the hardcoded pipeline with an intelligent agent
 that decides which tools to use and when.
 """
 
+import asyncio
 import json
 from typing import AsyncGenerator, Optional
 
@@ -267,7 +268,7 @@ async def chat_pipeline_streaming_agentic(
                     model = chat_models.get_generator_model()
                     chain = fiqh_prompt | model
                     response_tokens = []
-                    for chunk in chain.stream({
+                    async for chunk in chain.astream({
                         "query": user_query,
                         "evidence": _format_evidence(fiqh_docs),
                     }):
@@ -331,10 +332,14 @@ async def chat_pipeline_streaming_agentic(
                         chat_model = chat_models.get_generator_model()
                         prompt = prompt_templates.generator_prompt_template
                         chain = prompt | chat_model
-                        history_messages = make_history(runtime_session_id).messages
+                        # make_history hits sync redis-py; offload to a thread until Phase 4
+                        # (DEE-43) ships the redis.asyncio-backed AsyncRedisChatMessageHistory.
+                        history_messages = await asyncio.to_thread(
+                            lambda: make_history(runtime_session_id).messages
+                        )
 
                         response_tokens = []
-                        for chunk in chain.stream(
+                        async for chunk in chain.astream(
                             {
                                 "target_language": target_language,
                                 "query": user_query,

--- a/documentation/async_baseline.md
+++ b/documentation/async_baseline.md
@@ -41,3 +41,36 @@ A speedup of 1.0 means full serialisation; the Phase 7 gate requires
 }
 ```
 
+## phase-1 chain.astream (DEE-40) — 2026-04-29T19:22:59+00:00
+
+- mode: `in-process`
+- n: 10
+- wall_clock_s: **0.9699**
+- p50_s / p95_s: 0.9632 / 0.9686
+- throughput_rps: 10.3107
+- speedup_vs_serial: **7.733**
+
+```json
+{
+  "label": "phase-1 chain.astream (DEE-40)",
+  "mode": "in-process",
+  "n": 10,
+  "stubs": {
+    "llm_sleep_s": 0.2,
+    "retrieval_sleep_s": 0.1,
+    "per_token_sleep_s": 0.05,
+    "expected_per_request_s": 0.75,
+    "expected_serial_wall_s": 7.5
+  },
+  "wall_clock_s": 0.9699,
+  "p50_s": 0.9632,
+  "p95_s": 0.9686,
+  "min_s": 0.958,
+  "max_s": 0.9686,
+  "mean_s": 0.9629,
+  "throughput_rps": 10.3107,
+  "speedup_vs_serial": 7.733,
+  "timestamp": "2026-04-29T19:22:59+00:00"
+}
+```
+

--- a/tests/test_chain_astream_parity.py
+++ b/tests/test_chain_astream_parity.py
@@ -1,0 +1,115 @@
+"""
+Token-equivalence parity test for the Phase 1 (DEE-40) chain.stream → chain.astream
+swap in core/pipeline_langgraph.py.
+
+This test does NOT exercise the real pipeline; it isolates the contract we care
+about — that for the same input, `chain.stream` and `chain.astream` yield the
+same sequence of token strings against an identically-seeded model. If a future
+LangChain upgrade changes streaming semantics or chunk types, this test catches
+it without us having to run the whole agentic flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Iterator, List
+
+import pytest
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.prompts import ChatPromptTemplate
+
+
+_TOKENS = ["The ", "patience ", "is ", "rewarded ", "in ", "abundance."]
+
+
+class _ParityModel(BaseChatModel):
+    """Sync `_stream` and async `_astream` yield the exact same token sequence."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "parity-fake"
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop=None,
+        run_manager=None,
+        **kwargs,
+    ) -> ChatResult:
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="".join(_TOKENS)))]
+        )
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop=None,
+        run_manager=None,
+        **kwargs,
+    ) -> ChatResult:
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="".join(_TOKENS)))]
+        )
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop=None,
+        run_manager=None,
+        **kwargs,
+    ) -> Iterator[ChatGenerationChunk]:
+        for tok in _TOKENS:
+            yield ChatGenerationChunk(message=AIMessageChunk(content=tok))
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop=None,
+        run_manager=None,
+        **kwargs,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        for tok in _TOKENS:
+            yield ChatGenerationChunk(message=AIMessageChunk(content=tok))
+
+
+def _build_chain():
+    prompt = ChatPromptTemplate.from_messages([("human", "{query}")])
+    return prompt | _ParityModel()
+
+
+def _collect_sync_tokens() -> List[str]:
+    chain = _build_chain()
+    out: List[str] = []
+    for chunk in chain.stream({"query": "patience"}):
+        token = getattr(chunk, "content", str(chunk) if chunk is not None else "")
+        if token:
+            out.append(token)
+    return out
+
+
+async def _collect_async_tokens() -> List[str]:
+    chain = _build_chain()
+    out: List[str] = []
+    async for chunk in chain.astream({"query": "patience"}):
+        token = getattr(chunk, "content", str(chunk) if chunk is not None else "")
+        if token:
+            out.append(token)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_stream_and_astream_yield_identical_tokens():
+    sync_tokens = _collect_sync_tokens()
+    async_tokens = await _collect_async_tokens()
+
+    # The order, count, and content must be byte-for-byte identical so the
+    # SSE response_chunk events emitted to the client don't change shape
+    # after the Phase 1 swap.
+    assert sync_tokens == async_tokens
+    assert "".join(sync_tokens) == "".join(_TOKENS)

--- a/tests/test_concurrency_baseline.py
+++ b/tests/test_concurrency_baseline.py
@@ -1,5 +1,5 @@
 """
-Phase 0 (DEE-39) concurrency baseline.
+Async migration concurrency gate (DEE-36).
 
 Runs N=10 concurrent agentic pipeline calls against the stubbed in-process
 pipeline (see tests/conftest_async_stubs.py). Captures wall-clock, p50, p95,
@@ -10,14 +10,14 @@ Two gates here:
 
 1. `test_baseline_records_snapshot` always runs and writes a JSON snapshot
    to documentation/async_baseline.md. Never asserts on latency — this is
-   the BEFORE picture for later phases to compare against.
+   the per-phase record for later phases to compare against.
 
 2. `test_concurrency_threshold` asserts wall-clock < per_request_latency *
    1.5 — i.e. N concurrent requests finish in roughly the time of a single
-   request. langgraph already yields between sync nodes so Phase 0 sits at
-   ~4.5x and fails this gate; Phase 2/3 (async nodes + async modules) is
-   where the ratio drops below 1.5x. Marked `xfail(strict=True)` so the
-   migration is forced to flip it to passing and drop the marker.
+   request. Phase 0 sat at ~4.5x because the streaming generator's sync
+   `chain.stream` blocked the event loop; Phase 1 (DEE-40) swapped to
+   `chain.astream` and dropped the ratio to ~1.3x. The gate is now a hard
+   requirement for every later phase to keep passing.
 """
 
 from __future__ import annotations
@@ -32,6 +32,8 @@ from scripts.loadtest_agentic import _emit_snapshot, _run_in_process, parse_args
 
 
 _BASELINE_PATH = Path(__file__).resolve().parent.parent / "documentation" / "async_baseline.md"
+
+_DEFAULT_LABEL = "phase-1 chain.astream (DEE-40)"
 
 
 def _build_args(n: int, label: str):
@@ -51,8 +53,8 @@ def _build_args(n: int, label: str):
 
 @pytest.mark.asyncio
 async def test_baseline_records_snapshot():
-    """Always runs — emits the Phase 0 snapshot to documentation/async_baseline.md."""
-    label = os.environ.get("ASYNC_BASELINE_LABEL", "phase-0 baseline (DEE-39)")
+    """Always runs — appends the current-phase snapshot to documentation/async_baseline.md."""
+    label = os.environ.get("ASYNC_BASELINE_LABEL", _DEFAULT_LABEL)
     args = _build_args(n=10, label=label)
     payload = await _run_in_process(args)
 
@@ -64,20 +66,10 @@ async def test_baseline_records_snapshot():
     _emit_snapshot(_BASELINE_PATH, payload)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Real concurrency gate: wall-clock should approach single-request latency. "
-        "Phase 0 is ~4.5x because the agent's sync nodes / chain.stream / sync "
-        "Pinecone serialise on the event loop. Phase 2 (DEE-41) async nodes and "
-        "Phase 3 (DEE-42) async modules are where the ratio drops below 1.5x; "
-        "remove this marker once it XPASSes."
-    ),
-)
 @pytest.mark.asyncio
 async def test_concurrency_threshold():
     """Wall-clock < per_request * 1.5 — N requests should finish in ~one-request-time."""
-    args = _build_args(n=10, label="phase-0 threshold-check")
+    args = _build_args(n=10, label=f"{_DEFAULT_LABEL} threshold-check")
     payload = await _run_in_process(args)
 
     expected_per_request = payload["stubs"]["expected_per_request_s"]


### PR DESCRIPTION
…ators

Phase 1 of DEE-36. Both fiqh and hadith branches of response_generator() in core/pipeline_langgraph.py used sync `chain.stream()` inside an async generator, which blocked the event loop for the entire token stream of every concurrent request. Swap to `chain.astream()` so the worker can interleave multiple in-flight streams.

- core/pipeline_langgraph.py:271 (fiqh) — async for chunk in chain.astream(...)
- core/pipeline_langgraph.py:341 (hadith) — async for chunk in chain.astream(...)
- core/pipeline_langgraph.py:335 — make_history(...).messages still hits sync redis-py; wrap in await asyncio.to_thread(...) until DEE-43 ships the redis.asyncio-backed AsyncRedisChatMessageHistory.
- tests/test_chain_astream_parity.py — new: byte-for-byte token equivalence between chain.stream and chain.astream against an identically-seeded BaseChatModel subclass. Catches future LangChain semantic drift without exercising the whole agentic flow.
- tests/test_concurrency_baseline.py — drop xfail(strict=True); the wall < per_request * 1.5 gate now passes. Default label updated.

Phase 1 numbers (N=10, same stubs as Phase 0):
  wall_clock     3.45s → 0.97s   (3.55x improvement)
  p95            3.44s → 0.97s
  speedup_vs_serial 2.18x → 7.73x
  ratio          4.59x → 1.29x   (gate threshold: <1.5x)