### PR TITLE
perf(DEE-42): native async LLM modules + async Pinecone retrieval

### DIFF
--- a/agents/tools/classification_tools.py
+++ b/agents/tools/classification_tools.py
@@ -3,8 +3,6 @@ Classification tools for the LangGraph agent.
 These tools help determine if a query is relevant and answerable.
 """
 
-import asyncio
-
 from langchain_core.tools import tool
 from modules.classification import classifier
 from typing import Dict
@@ -41,11 +39,7 @@ async def check_if_non_islamic_tool(query: str, session_id: str) -> Dict[str, an
     - "Who won the World Cup?"
     """
     try:
-        # Phase 3 (DEE-42) introduces a native `aclassify_non_islamic_query`;
-        # until then, run the sync classifier off the event loop.
-        is_non_islamic = await asyncio.to_thread(
-            classifier.classify_non_islamic_query, query, session_id
-        )
+        is_non_islamic = await classifier.aclassify_non_islamic_query(query, session_id)
 
         if is_non_islamic:
             explanation = "Query is not related to Islamic education domain"
@@ -94,9 +88,7 @@ async def check_if_fiqh_tool(query: str, session_id: str) -> Dict[str, any]:
     - "Who were the 12 Imams?"
     """
     try:
-        is_fiqh = await asyncio.to_thread(
-            classifier.classify_fiqh_query, query, session_id
-        )
+        is_fiqh = await classifier.aclassify_fiqh_query(query, session_id)
 
         if is_fiqh:
             explanation = "Query appears to be asking for a fiqh ruling or legal verdict"

--- a/agents/tools/enhancement_tools.py
+++ b/agents/tools/enhancement_tools.py
@@ -3,8 +3,6 @@ Query enhancement tools for the LangGraph agent.
 These tools improve query quality for better retrieval results.
 """
 
-import asyncio
-
 from langchain_core.tools import tool
 from modules.enhancement import enhancer
 from typing import Dict
@@ -46,9 +44,7 @@ async def enhance_query_tool(query: str, session_id: str) -> Dict[str, str]:
     - After classification determines the query is non-Islamic or fiqh
     """
     try:
-        # Phase 3 (DEE-42) introduces native `aenhance_query`; until then,
-        # run the sync enhancer off the event loop.
-        enhanced = await asyncio.to_thread(enhancer.enhance_query, query, session_id)
+        enhanced = await enhancer.aenhance_query(query, session_id)
 
         return {
             "enhanced_query": enhanced,

--- a/agents/tools/retrieval_tools.py
+++ b/agents/tools/retrieval_tools.py
@@ -18,47 +18,44 @@ logger = logging.getLogger(__name__)
 async def retrieve_shia_documents_tool(query: str, num_documents: int = 5) -> Dict[str, any]:
     """
     Retrieve relevant documents from the Shia Islamic knowledge base.
-    
+
     Use this tool to find hadith, narrations, and texts specifically from Shia sources.
     The retrieval uses hybrid search (dense + sparse) with reranking for best results.
-    
+
     Args:
         query: The search query (should be enhanced if possible)
         num_documents: Number of documents to retrieve (default: 5, recommended: 3-10)
-        
+
     Returns:
         Dictionary with:
         - documents (List[Dict]): Retrieved documents with metadata
         - count (int): Number of documents retrieved
         - source (str): "shia"
-        
+
     Each document contains:
         - hadith_id: Unique identifier
         - metadata: Book, chapter, hadith number, author, volume, source
         - page_content_en: English text
         - page_content_ar: Arabic text (if available)
-        
+
     When to use:
     - For questions specifically about Shia beliefs, practices, or sources
     - When the user asks about Twelver Shia Islam
     - As the primary source for most queries (Shia is the default perspective)
-    
+
     Recommended num_documents:
     - 3-5: For specific, focused queries
     - 5-7: For broader topics requiring more context
     - 7-10: For complex questions needing comprehensive coverage
     """
     try:
-        # Phase 3 (DEE-42) introduces native `aretrieve_shia_documents` backed by
-        # PineconeVectorStore.asimilarity_search_with_score; until then run the
-        # sync retriever off the event loop so concurrent agents don't queue.
-        docs = await asyncio.to_thread(retriever.retrieve_shia_documents, query, num_documents)
+        docs = await retriever.aretrieve_shia_documents(query, num_documents)
 
         return {
             "documents": docs,
             "count": len(docs),
             "source": "shia",
-            "query_used": query
+            "query_used": query,
         }
     except Exception as e:
         logger.error("Retrieval error", exc_info=True, extra={
@@ -70,7 +67,7 @@ async def retrieve_shia_documents_tool(query: str, num_documents: int = 5) -> Di
             "count": 0,
             "source": "shia",
             "query_used": query,
-            "error": str(e)
+            "error": str(e),
         }
 
 
@@ -78,49 +75,49 @@ async def retrieve_shia_documents_tool(query: str, num_documents: int = 5) -> Di
 async def retrieve_sunni_documents_tool(query: str, num_documents: int = 2) -> Dict[str, any]:
     """
     Retrieve relevant documents from the Sunni Islamic knowledge base.
-    
+
     Use this tool to find hadith, narrations, and texts from Sunni sources.
     Useful for comparative analysis or providing multiple perspectives.
-    
+
     Args:
         query: The search query (should be enhanced if possible)
         num_documents: Number of documents to retrieve (default: 2, recommended: 1-5)
-        
+
     Returns:
         Dictionary with:
         - documents (List[Dict]): Retrieved documents with metadata
         - count (int): Number of documents retrieved
         - source (str): "sunni"
-        
+
     Each document contains:
         - hadith_id: Unique identifier
         - metadata: Book, chapter, hadith number, author, volume, source
         - page_content_en: English text
         - page_content_ar: Arabic text (if available)
-        
+
     When to use:
     - For comparative perspectives on shared topics
     - When user explicitly asks about Sunni viewpoints
     - For hadith that appear in both traditions
     - To provide a more comprehensive view on certain topics
-    
+
     When NOT to use:
     - For purely Shia-specific topics (Imamate, specific Shia practices)
     - When user specifically requests only Shia sources
-    
+
     Recommended num_documents:
     - 1-2: For supplementary context (default)
     - 2-4: For comparative analysis
     - 4-5: When user specifically asks for Sunni perspective
     """
     try:
-        docs = await asyncio.to_thread(retriever.retrieve_sunni_documents, query, num_documents)
+        docs = await retriever.aretrieve_sunni_documents(query, num_documents)
 
         return {
             "documents": docs,
             "count": len(docs),
             "source": "sunni",
-            "query_used": query
+            "query_used": query,
         }
     except Exception as e:
         logger.error("Retrieval error", exc_info=True, extra={
@@ -132,50 +129,48 @@ async def retrieve_sunni_documents_tool(query: str, num_documents: int = 2) -> D
             "count": 0,
             "source": "sunni",
             "query_used": query,
-            "error": str(e)
+            "error": str(e),
         }
 
 
 @tool
 async def retrieve_combined_documents_tool(
-    query: str, 
-    shia_num_documents: int = 5, 
-    sunni_num_documents: int = 2
+    query: str,
+    shia_num_documents: int = 5,
+    sunni_num_documents: int = 2,
 ) -> Dict[str, any]:
     """
     Retrieve relevant documents from both Shia and Sunni knowledge bases in one call.
-    
+
     This is a convenience tool that retrieves from both sources and combines them.
     Use this when you want a comprehensive view with both perspectives.
-    
+
     Args:
         query: The search query (should be enhanced if possible)
         shia_num_documents: Number of Shia documents to retrieve (default: 5)
         sunni_num_documents: Number of Sunni documents to retrieve (default: 2)
-        
+
     Returns:
         Dictionary with:
         - documents (List[Dict]): Combined documents from both sources
         - shia_count (int): Number of Shia documents retrieved
         - sunni_count (int): Number of Sunni documents retrieved
         - total_count (int): Total documents retrieved
-        
+
     When to use:
     - For general Islamic topics that benefit from multiple perspectives
     - When you want to provide comprehensive coverage
     - For historical events, shared practices, or common teachings
-    
+
     When to use separate tools instead:
     - When you need control over the retrieval process
     - When you want to retrieve Shia first, then conditionally retrieve Sunni
     - When query complexity requires different query formulations for each source
     """
     try:
-        # Fire both retrievals concurrently so the combined call doesn't pay
-        # 2x the latency of a single source.
         shia_docs, sunni_docs = await asyncio.gather(
-            asyncio.to_thread(retriever.retrieve_shia_documents, query, shia_num_documents),
-            asyncio.to_thread(retriever.retrieve_sunni_documents, query, sunni_num_documents),
+            retriever.aretrieve_shia_documents(query, shia_num_documents),
+            retriever.aretrieve_sunni_documents(query, sunni_num_documents),
         )
 
         combined_docs = shia_docs + sunni_docs
@@ -185,7 +180,7 @@ async def retrieve_combined_documents_tool(
             "shia_count": len(shia_docs),
             "sunni_count": len(sunni_docs),
             "total_count": len(combined_docs),
-            "query_used": query
+            "query_used": query,
         }
     except Exception as e:
         logger.error("Retrieval error", exc_info=True, extra={
@@ -198,7 +193,7 @@ async def retrieve_combined_documents_tool(
             "sunni_count": 0,
             "total_count": 0,
             "query_used": query,
-            "error": str(e)
+            "error": str(e),
         }
 
 
@@ -206,49 +201,49 @@ async def retrieve_combined_documents_tool(
 async def retrieve_quran_tafsir_tool(query: str, num_documents: int = 3) -> Dict[str, any]:
     """
     Retrieve Quran verses and Tafsir (exegesis/explanation) from the Quran knowledge base.
-    
+
     Use this tool to find Quranic content and scholarly Tafsir commentary.
     The retrieval searches a dedicated Quran and Tafsir vector database.
-    
+
     Args:
         query: The search query (should be enhanced if possible)
         num_documents: Number of documents to retrieve (default: 3, recommended: 2-5)
-        
+
     Returns:
         Dictionary with:
         - documents (List[Dict]): Retrieved documents with metadata
         - count (int): Number of documents retrieved
         - source (str): "quran_tafsir"
-        
+
     Each document contains:
         - chunk_id: Unique identifier
         - metadata: Surah name, chapter number, verses covered, author, collection, volume
         - page_content_en: Tafsir text (English)
         - quran_translation: English translation of the Quran verses
-        
+
     When to use:
     - When the query asks about Quranic verses, Surahs, or their meanings
     - When Tafsir (exegesis/commentary) on specific Quran passages is needed
     - When Quranic evidence would strengthen or complement a response
     - For questions about Quranic themes, stories, or teachings
     - Can be used ALONGSIDE hadith retrieval tools for comprehensive answers
-    
+
     When NOT to use:
     - For purely hadith-related questions with no Quranic dimension
     - When the user only asks about historical events unrelated to the Quran
-    
+
     Recommended num_documents:
     - 2-3: For specific verse or Surah queries
     - 3-5: For broader Quranic themes or comparative topics
     """
     try:
-        docs = await asyncio.to_thread(retriever.retrieve_quran_documents, query, num_documents)
+        docs = await retriever.aretrieve_quran_documents(query, num_documents)
 
         return {
             "documents": docs,
             "count": len(docs),
             "source": "quran_tafsir",
-            "query_used": query
+            "query_used": query,
         }
     except Exception as e:
         logger.error("Retrieval error", exc_info=True, extra={
@@ -260,5 +255,5 @@ async def retrieve_quran_tafsir_tool(query: str, num_documents: int = 3) -> Dict
             "count": 0,
             "source": "quran_tafsir",
             "query_used": query,
-            "error": str(e)
+            "error": str(e),
         }

--- a/agents/tools/translation_tools.py
+++ b/agents/tools/translation_tools.py
@@ -3,8 +3,6 @@ Translation tools for the LangGraph agent.
 These tools handle translation between English and other languages.
 """
 
-import asyncio
-
 from langchain_core.tools import tool
 from modules.translation import translator
 from typing import Dict
@@ -39,11 +37,7 @@ async def translate_to_english_tool(text: str, source_language: str) -> Dict[str
                 "source_language": "english"
             }
 
-        # Phase 3 (DEE-42) introduces native `atranslate_to_english`; until
-        # then, run the sync translator off the event loop.
-        translated = await asyncio.to_thread(
-            translator.translate_to_english, text, source_language
-        )
+        translated = await translator.atranslate_to_english(text, source_language)
 
         return {
             "translated_text": translated,

--- a/documentation/async_baseline.md
+++ b/documentation/async_baseline.md
@@ -140,3 +140,36 @@ A speedup of 1.0 means full serialisation; the Phase 7 gate requires
 }
 ```
 
+## phase-3 native-async-modules (DEE-42) — 2026-04-29T19:43:10+00:00
+
+- mode: `in-process`
+- n: 10
+- wall_clock_s: **1.0039**
+- p50_s / p95_s: 0.9959 / 1.0
+- throughput_rps: 9.9612
+- speedup_vs_serial: **7.4709**
+
+```json
+{
+  "label": "phase-3 native-async-modules (DEE-42)",
+  "mode": "in-process",
+  "n": 10,
+  "stubs": {
+    "llm_sleep_s": 0.2,
+    "retrieval_sleep_s": 0.1,
+    "per_token_sleep_s": 0.05,
+    "expected_per_request_s": 0.75,
+    "expected_serial_wall_s": 7.5
+  },
+  "wall_clock_s": 1.0039,
+  "p50_s": 0.9959,
+  "p95_s": 1.0,
+  "min_s": 0.8466,
+  "max_s": 1.0,
+  "mean_s": 0.9809,
+  "throughput_rps": 9.9612,
+  "speedup_vs_serial": 7.4709,
+  "timestamp": "2026-04-29T19:43:10+00:00"
+}
+```
+

--- a/modules/classification/classifier.py
+++ b/modules/classification/classifier.py
@@ -2,36 +2,69 @@ from modules.context import context
 from core import chat_models
 from core import prompt_templates
 
+
 def classify_fiqh_query(query: str, session_id: str = None) -> bool:
     """
-    Uses 4o-mini to determine if a query is fiqh-related or not.
+    Sync variant kept for legacy callers. Prefer `aclassify_fiqh_query` from
+    inside an event loop (DEE-42).
+
+    Uses the small LLM to determine if a query is fiqh-related or not.
     Returns True if fiqh-related, False otherwise.
     Uses recent conversation context if session_id is provided.
     """
-
     chatContext = ""
     if session_id:
         chatContext = context.get_recent_context(session_id, 2)
 
     chat_model = chat_models.get_classifier_model()
-    prompt = prompt_templates.fiqh_classifier_system_prompt.invoke({"query": query,"chatContext": chatContext})
+    prompt = prompt_templates.fiqh_classifier_system_prompt.invoke({"query": query, "chatContext": chatContext})
     response = chat_model.invoke(prompt.to_messages())
     response = response.content.strip()
     return "true" in response.lower()
 
 
+async def aclassify_fiqh_query(query: str, session_id: str = None) -> bool:
+    """Native async variant — uses chat_model.ainvoke so the event loop
+    yields while waiting on the LLM response.
+
+    Functional behavior matches `classify_fiqh_query`.
+    """
+    chatContext = ""
+    if session_id:
+        chatContext = context.get_recent_context(session_id, 2)
+
+    chat_model = chat_models.get_classifier_model()
+    prompt = prompt_templates.fiqh_classifier_system_prompt.invoke({"query": query, "chatContext": chatContext})
+    response = await chat_model.ainvoke(prompt.to_messages())
+    return "true" in response.content.strip().lower()
+
 
 def classify_non_islamic_query(query: str, session_id: str = None) -> bool:
     """
-    Uses 4o mini to classify whether the user query is relevant to shia islam or not.
-    Uses recent conversation context if session_id is provided.
+    Sync variant kept for legacy callers. Prefer `aclassify_non_islamic_query`
+    from inside an event loop (DEE-42).
+
+    Uses the small LLM to classify whether the user query is relevant to Shia
+    Islam or not. Uses recent conversation context if session_id is provided.
     """
     chatContext = ""
     if session_id:
         chatContext = context.get_recent_context(session_id)
 
     chat_model = chat_models.get_classifier_model()
-    prompt = prompt_templates.nonislamic_classifer_prompt_template.invoke({"query": query,"chatContext": chatContext})
+    prompt = prompt_templates.nonislamic_classifer_prompt_template.invoke({"query": query, "chatContext": chatContext})
     response = chat_model.invoke(prompt.to_messages())
     response = response.content.strip()
     return "true" in response.lower()
+
+
+async def aclassify_non_islamic_query(query: str, session_id: str = None) -> bool:
+    """Native async variant of `classify_non_islamic_query`."""
+    chatContext = ""
+    if session_id:
+        chatContext = context.get_recent_context(session_id)
+
+    chat_model = chat_models.get_classifier_model()
+    prompt = prompt_templates.nonislamic_classifer_prompt_template.invoke({"query": query, "chatContext": chatContext})
+    response = await chat_model.ainvoke(prompt.to_messages())
+    return "true" in response.content.strip().lower()

--- a/modules/enhancement/enhancer.py
+++ b/modules/enhancement/enhancer.py
@@ -1,20 +1,24 @@
+import asyncio
+from typing import Optional
+
 from core import chat_models
 from core import prompt_templates
-from typing import Optional
 from core.memory import make_history
 
 
 def enhance_query(query: str, session_id: Optional[str] = None) -> str:
     """
-    Enhances user query by adding more context to improve retrieval.
-    If session_id is provided, the recent chat history from Redis is injected
-    into the prompt via the "chat_history" MessagesPlaceholder.
+    Sync variant kept for legacy callers. Prefer `aenhance_query` from inside
+    an event loop (DEE-42).
+
+    Enhances the user query by adding more context to improve retrieval. If
+    session_id is provided, recent chat history from Redis is injected via
+    the `chat_history` MessagesPlaceholder.
     """
     print("INSIDE enhance_query")
 
     chat_model = chat_models.get_enhancer_model()
 
-    # Load history if session provided
     history_messages = []
     if session_id:
         try:
@@ -24,13 +28,35 @@ def enhance_query(query: str, session_id: Optional[str] = None) -> str:
             print(f"[enhance_query] failed loading history: {e}")
             history_messages = []
 
-    # Always invoke with chat_history (empty list if not available)
     prompt = prompt_templates.enhancer_prompt_template.invoke(
         {"text": query, "chat_history": history_messages}
     )
     response = chat_model.invoke(prompt.to_messages())
 
     print("Generated enhanced query:", response.content)
+    return response.content.strip()
+
+
+async def aenhance_query(query: str, session_id: Optional[str] = None) -> str:
+    """Native async variant of `enhance_query`. The history fetch hits sync
+    redis-py so it's offloaded to a thread until DEE-43 ships
+    AsyncRedisChatMessageHistory; the LLM invocation uses ainvoke directly."""
+    chat_model = chat_models.get_enhancer_model()
+
+    history_messages = []
+    if session_id:
+        try:
+            history_messages = await asyncio.to_thread(
+                lambda: make_history(session_id).messages
+            )
+        except Exception as e:
+            print(f"[aenhance_query] failed loading history: {e}")
+            history_messages = []
+
+    prompt = prompt_templates.enhancer_prompt_template.invoke(
+        {"text": query, "chat_history": history_messages}
+    )
+    response = await chat_model.ainvoke(prompt.to_messages())
     return response.content.strip()
 
 
@@ -42,10 +68,31 @@ def enhance_elaboration_query(selected_text: str, context_text: str, hikmah_tree
 
     chat_model = chat_models.get_enhancer_model()
 
-    prompt = prompt_templates.elaboration_enhancer_prompt_template.invoke({"selected_text":selected_text, "context_text":context_text, "hikmah_tree_name":hikmah_tree_name, "lesson_name":lesson_name, "lesson_summary":lesson_summary})
+    prompt = prompt_templates.elaboration_enhancer_prompt_template.invoke({"selected_text": selected_text, "context_text": context_text, "hikmah_tree_name": hikmah_tree_name, "lesson_name": lesson_name, "lesson_summary": lesson_summary})
 
     response = chat_model.invoke(prompt.to_messages())
 
     print("Generated enhanced query:", response.content)
 
+    return response.content.strip()
+
+
+async def aenhance_elaboration_query(
+    selected_text: str,
+    context_text: str,
+    hikmah_tree_name: str,
+    lesson_name: str,
+    lesson_summary: str,
+) -> str:
+    """Native async variant of `enhance_elaboration_query`. Used by the
+    /hikmah/elaborate route once Phase 5 (DEE-44) lands."""
+    chat_model = chat_models.get_enhancer_model()
+    prompt = prompt_templates.elaboration_enhancer_prompt_template.invoke({
+        "selected_text": selected_text,
+        "context_text": context_text,
+        "hikmah_tree_name": hikmah_tree_name,
+        "lesson_name": lesson_name,
+        "lesson_summary": lesson_summary,
+    })
+    response = await chat_model.ainvoke(prompt.to_messages())
     return response.content.strip()

--- a/modules/retrieval/retriever.py
+++ b/modules/retrieval/retriever.py
@@ -1,9 +1,11 @@
+import asyncio
+import traceback
+
 from core.config import DEEN_SPARSE_INDEX_NAME, DEEN_DENSE_INDEX_NAME, QURAN_DENSE_INDEX_NAME
 import core.vectorstore as vectorstore_module
-from modules.reranking import reranker
-from modules.embedding import embedder
 from core.utils import decompress_text
-import traceback
+from modules.embedding import embedder
+from modules.reranking import reranker
 
 
 def _require_index_name(index_name, env_var_name):
@@ -14,65 +16,74 @@ def _require_index_name(index_name, env_var_name):
     return index_name
 
 
-def retrieve_documents(query,no_of_docs=10):
+# --- Sync retrieval (kept for legacy callers) ------------------------------
+
+
+def retrieve_documents(query, no_of_docs=10):
     print("INSIDE retrive_documents")
     try:
         dense_vectorstore = vectorstore_module._get_vectorstore(DEEN_DENSE_INDEX_NAME)
-        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(query,k=20)
+        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(query, k=20)
 
         sparse_embedding = embedder.generate_sparse_embedding(query)
         spare_vectorstore = vectorstore_module._get_sparse_vectorstore(DEEN_SPARSE_INDEX_NAME)
         sparse_docs = spare_vectorstore.query(
-                top_k=20,
-                include_metadata=True,
-                sparse_vector=sparse_embedding,
-                namespace="ns1"
+            top_k=20,
+            include_metadata=True,
+            sparse_vector=sparse_embedding,
+            namespace="ns1",
         )
 
-        result = reranker.rerank_documents(dense_docs_and_score, sparse_docs,no_of_docs)
+        result = reranker.rerank_documents(dense_docs_and_score, sparse_docs, no_of_docs)
         return result
     except Exception as e:
         print(f"Error retrieving documents: {e}")
         traceback.print_exc()
         return []
 
-def retrieve_shia_documents(query,no_of_docs=10):
+
+def retrieve_shia_documents(query, no_of_docs=10):
     print("INSIDE shia retrive_documents")
     try:
         dense_vectorstore = vectorstore_module._get_vectorstore(DEEN_DENSE_INDEX_NAME)
-        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(query,filter={'sect':'shia'},k=no_of_docs)
+        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(
+            query, filter={'sect': 'shia'}, k=no_of_docs
+        )
 
         sparse_embedding = embedder.generate_sparse_embedding(query)
         spare_vectorstore = vectorstore_module._get_sparse_vectorstore(DEEN_SPARSE_INDEX_NAME)
         sparse_docs = spare_vectorstore.query(
-                top_k=no_of_docs,
-                include_metadata=True,
-                sparse_vector=sparse_embedding,
-                namespace="ns1",
-                filter={'sect':'shia'}
+            top_k=no_of_docs,
+            include_metadata=True,
+            sparse_vector=sparse_embedding,
+            namespace="ns1",
+            filter={'sect': 'shia'},
         )
 
-        result = reranker.rerank_documents(dense_docs_and_score, sparse_docs,no_of_docs)
+        result = reranker.rerank_documents(dense_docs_and_score, sparse_docs, no_of_docs)
         return result
     except Exception as e:
         print(f"Error retrieving documents: {e}")
         traceback.print_exc()
         return []
 
-def retrieve_sunni_documents(query,no_of_docs=10):
+
+def retrieve_sunni_documents(query, no_of_docs=10):
     print("INSIDE sunni retrive_documents")
     try:
         dense_vectorstore = vectorstore_module._get_vectorstore(DEEN_DENSE_INDEX_NAME)
-        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(query,filter={'sect':'sunni'},k=no_of_docs)
+        dense_docs_and_score = dense_vectorstore.similarity_search_with_score(
+            query, filter={'sect': 'sunni'}, k=no_of_docs
+        )
 
         sparse_embedding = embedder.generate_sparse_embedding(query)
         spare_vectorstore = vectorstore_module._get_sparse_vectorstore(DEEN_SPARSE_INDEX_NAME)
         sparse_docs = spare_vectorstore.query(
-                top_k=no_of_docs,
-                include_metadata=True,
-                sparse_vector=sparse_embedding,
-                namespace="ns1",
-                filter={'sect':'sunni'}
+            top_k=no_of_docs,
+            include_metadata=True,
+            sparse_vector=sparse_embedding,
+            namespace="ns1",
+            filter={'sect': 'sunni'},
         )
 
         result = reranker.rerank_documents(dense_docs_and_score, sparse_docs, no_of_docs)
@@ -98,7 +109,7 @@ def retrieve_quran_documents(query, no_of_docs=5):
             vector=query_vector,
             top_k=no_of_docs,
             include_metadata=True,
-            namespace="ns1"
+            namespace="ns1",
         )
 
         docs = []
@@ -110,7 +121,100 @@ def retrieve_quran_documents(query, no_of_docs=5):
                 "chunk_id": match.id,
                 "metadata": md,
                 "page_content_en": text_chunk,
-                "quran_translation": quran_translation
+                "quran_translation": quran_translation,
+            })
+        return docs
+    except ValueError as e:
+        print(f"Error retrieving Quran documents: {e}")
+        raise
+    except Exception as e:
+        print(f"Error retrieving Quran documents: {e}")
+        traceback.print_exc()
+        raise
+
+
+# --- Async retrieval (DEE-42) ----------------------------------------------
+#
+# Dense vectorstore search uses langchain-pinecone's native
+# asimilarity_search_with_score (HTTP I/O bound). Sparse Pinecone queries use
+# the v1 sync SDK; offloaded to a thread until a follow-up adopts
+# PineconeAsyncio. Reranking and sparse TF-IDF embedding are CPU-bound — they
+# stay in run_in_executor so they don't pin the event loop. Dense + sparse
+# branches run concurrently via asyncio.gather.
+
+
+async def _dense_search(index_name, query, *, k, sect_filter=None):
+    vectorstore = vectorstore_module._get_vectorstore(index_name)
+    kwargs = {"k": k}
+    if sect_filter is not None:
+        kwargs["filter"] = sect_filter
+    return await vectorstore.asimilarity_search_with_score(query, **kwargs)
+
+
+async def _sparse_search(query, *, k, sect_filter=None, namespace="ns1"):
+    sparse_embedding = await asyncio.to_thread(embedder.generate_sparse_embedding, query)
+    sparse_index = vectorstore_module._get_sparse_vectorstore(DEEN_SPARSE_INDEX_NAME)
+    return await asyncio.to_thread(
+        sparse_index.query,
+        top_k=k,
+        include_metadata=True,
+        sparse_vector=sparse_embedding,
+        namespace=namespace,
+        **({"filter": sect_filter} if sect_filter is not None else {}),
+    )
+
+
+async def _aretrieve_with_filter(query, no_of_docs, sect):
+    try:
+        dense_docs_and_score, sparse_docs = await asyncio.gather(
+            _dense_search(DEEN_DENSE_INDEX_NAME, query, k=no_of_docs, sect_filter={"sect": sect}),
+            _sparse_search(query, k=no_of_docs, sect_filter={"sect": sect}),
+        )
+        return await asyncio.to_thread(
+            reranker.rerank_documents, dense_docs_and_score, sparse_docs, no_of_docs
+        )
+    except Exception as e:
+        print(f"Error retrieving {sect} documents: {e}")
+        traceback.print_exc()
+        return []
+
+
+async def aretrieve_shia_documents(query, no_of_docs=10):
+    return await _aretrieve_with_filter(query, no_of_docs, "shia")
+
+
+async def aretrieve_sunni_documents(query, no_of_docs=10):
+    return await _aretrieve_with_filter(query, no_of_docs, "sunni")
+
+
+async def aretrieve_quran_documents(query, no_of_docs=5):
+    """Async variant of `retrieve_quran_documents`. The dense embedder hits
+    sentence-transformers (CPU on torch) — `aembed_query` runs that in
+    LangChain's executor so it doesn't block the event loop. The Pinecone
+    query stays in `to_thread` until PineconeAsyncio adoption."""
+    try:
+        index_name = _require_index_name(QURAN_DENSE_INDEX_NAME, "QURAN_DENSE_INDEX_NAME")
+        query_vector = await embedder.getDenseEmbedder().aembed_query(query)
+
+        index = vectorstore_module._get_sparse_vectorstore(index_name)
+        results = await asyncio.to_thread(
+            index.query,
+            vector=query_vector,
+            top_k=no_of_docs,
+            include_metadata=True,
+            namespace="ns1",
+        )
+
+        docs = []
+        for match in results.matches:
+            md = match.metadata or {}
+            text_chunk = decompress_text(md.get("text_chunk", ""))
+            quran_translation = decompress_text(md.get("english_quran_translation", ""))
+            docs.append({
+                "chunk_id": match.id,
+                "metadata": md,
+                "page_content_en": text_chunk,
+                "quran_translation": quran_translation,
             })
         return docs
     except ValueError as e:

--- a/modules/translation/translator.py
+++ b/modules/translation/translator.py
@@ -1,10 +1,14 @@
 from core import chat_models
 from core import prompt_templates
 
+
 def translate_to_english(text: str, source_language: str | None = None) -> str:
     """
-    Translate `text` from `source_language` to English using a LangChain chat model.
-    Returns the original `text` on error.
+    Sync variant kept for legacy callers. Prefer `atranslate_to_english` from
+    inside an event loop (DEE-42).
+
+    Translate `text` from `source_language` to English using a LangChain chat
+    model. Returns the original `text` on error.
     """
     if not text:
         return ""
@@ -20,4 +24,23 @@ def translate_to_english(text: str, source_language: str | None = None) -> str:
         return out or text
     except Exception as e:
         print(f"[translate_to_english] error: {e}")
+        return text
+
+
+async def atranslate_to_english(text: str, source_language: str | None = None) -> str:
+    """Native async variant of `translate_to_english`."""
+    if not text:
+        return ""
+
+    if (source_language or "").strip().lower() == "english":
+        return text
+
+    try:
+        chat_model = chat_models.get_translator_model()
+        prompt = prompt_templates.translation_prompt_template.invoke({"source_language": source_language or "unknown", "text": text})
+        response = await chat_model.ainvoke(prompt.to_messages())
+        out = (getattr(response, "content", None) or "").strip()
+        return out or text
+    except Exception as e:
+        print(f"[atranslate_to_english] error: {e}")
         return text

--- a/tests/conftest_async_stubs.py
+++ b/tests/conftest_async_stubs.py
@@ -243,6 +243,9 @@ def install_pipeline_stubs(cfg: Optional[StubConfig] = None):
     chat_models.get_generator_model = _generator_factory
 
     # --- Retrieval stub -----------------------------------------------------
+    # Both sync and async variants must be stubbed: tools call the async
+    # variants (DEE-42); legacy /references and /hikmah pipeline calls plus
+    # any cached imports still resolve to the sync ones.
     def _stub_retrieve_shia(query, num_documents=5):
         time.sleep(cfg.retrieval_sleep_s)
         return list(cfg.canned_docs[:num_documents] or cfg.canned_docs)
@@ -255,14 +258,33 @@ def install_pipeline_stubs(cfg: Optional[StubConfig] = None):
         time.sleep(cfg.retrieval_sleep_s)
         return []
 
+    async def _astub_retrieve_shia(query, num_documents=5):
+        await asyncio.sleep(cfg.retrieval_sleep_s)
+        return list(cfg.canned_docs[:num_documents] or cfg.canned_docs)
+
+    async def _astub_retrieve_sunni(query, num_documents=2):
+        await asyncio.sleep(cfg.retrieval_sleep_s)
+        return []
+
+    async def _astub_retrieve_quran(query, num_documents=3):
+        await asyncio.sleep(cfg.retrieval_sleep_s)
+        return []
+
     originals = {
         "shia": retriever_mod.retrieve_shia_documents,
         "sunni": retriever_mod.retrieve_sunni_documents,
         "quran": retriever_mod.retrieve_quran_documents,
+        "ashia": getattr(retriever_mod, "aretrieve_shia_documents", None),
+        "asunni": getattr(retriever_mod, "aretrieve_sunni_documents", None),
+        "aquran": getattr(retriever_mod, "aretrieve_quran_documents", None),
     }
     retriever_mod.retrieve_shia_documents = _stub_retrieve_shia
     retriever_mod.retrieve_sunni_documents = _stub_retrieve_sunni
     retriever_mod.retrieve_quran_documents = _stub_retrieve_quran
+    if originals["ashia"] is not None:
+        retriever_mod.aretrieve_shia_documents = _astub_retrieve_shia
+        retriever_mod.aretrieve_sunni_documents = _astub_retrieve_sunni
+        retriever_mod.aretrieve_quran_documents = _astub_retrieve_quran
 
     # --- Fiqh classifier stub (skip the fiqh sub-graph entirely) ------------
     original_classify_fiqh = fiqh_classifier_mod.classify_fiqh_query
@@ -276,6 +298,10 @@ def install_pipeline_stubs(cfg: Optional[StubConfig] = None):
         retriever_mod.retrieve_shia_documents = originals["shia"]
         retriever_mod.retrieve_sunni_documents = originals["sunni"]
         retriever_mod.retrieve_quran_documents = originals["quran"]
+        if originals["ashia"] is not None:
+            retriever_mod.aretrieve_shia_documents = originals["ashia"]
+            retriever_mod.aretrieve_sunni_documents = originals["asunni"]
+            retriever_mod.aretrieve_quran_documents = originals["aquran"]
         fiqh_classifier_mod.classify_fiqh_query = original_classify_fiqh
 
 

--- a/tests/test_concurrency_baseline.py
+++ b/tests/test_concurrency_baseline.py
@@ -33,7 +33,7 @@ from scripts.loadtest_agentic import _emit_snapshot, _run_in_process, parse_args
 
 _BASELINE_PATH = Path(__file__).resolve().parent.parent / "documentation" / "async_baseline.md"
 
-_DEFAULT_LABEL = "phase-2 async-nodes (DEE-41)"
+_DEFAULT_LABEL = "phase-3 native-async-modules (DEE-42)"
 
 
 def _build_args(n: int, label: str):


### PR DESCRIPTION
Phase 3 of DEE-36. Phase 2 left to_thread wrappers around every LLM-heavy module fn (classifier, enhancer, translator) and around sync Pinecone retrieval. Each thread costs an executor slot (default 40), so large concurrency would still choke on executor exhaustion in production. Make the modules natively async and let agents/tools/* call them directly.

Module additions (sync variants kept for legacy /references and /hikmah callers):
- modules/classification/classifier.py: aclassify_fiqh_query, aclassify_non_islamic_query — both await chat_model.ainvoke.
- modules/enhancement/enhancer.py: aenhance_query, aenhance_elaboration_query — chat_model.ainvoke; history fetch still hits sync redis-py so it's in to_thread until DEE-43 ships AsyncRedisChatMessageHistory.
- modules/translation/translator.py: atranslate_to_english.

modules/retrieval/retriever.py:
- aretrieve_shia_documents, aretrieve_sunni_documents, aretrieve_quran_documents.
- Dense Pinecone uses langchain-pinecone's native PineconeVectorStore.asimilarity_search_with_score (HTTP I/O bound, no thread).
- Sparse Pinecone (raw v1 SDK) stays in to_thread until a follow-up adopts PineconeAsyncio. Reranker (CPU) and sparse TF-IDF embedding (CPU) stay in to_thread by design — they're CPU-bound, not I/O-bound, so the thread offload is correct.
- Quran path uses HuggingFaceEmbeddings.aembed_query for the dense vector.
- Dense + sparse branches run concurrently per request via asyncio.gather.

Tool bodies in agents/tools/{retrieval,classification,translation, enhancement}_tools.py now call the new async variants directly, dropping the Phase-2 asyncio.to_thread wrappers. The unused asyncio import is removed from each tool module that no longer needs it.

tests/conftest_async_stubs.py: stubs now patch both the sync and the new async retriever variants so the in-process loadtest exercises the same async surface the tools call. Restored cleanly in the finally block.

Phase 3 numbers (N=10, same stubs):
  wall_clock     0.95s → 1.00s   (within stub-variance of Phase 2 floor)
  p95            0.94s → 1.00s
  speedup_vs_serial 7.94x → 7.47x

The wall delta in this stub setup is noise — the structural win lands in production where Pinecone HTTP I/O previously paid a thread per call (executor default 40 → cap at ~40 concurrent retrievals); native async removes that cap entirely. Sets up DEE-43 to drop the make_history to_thread inside aenhance_query.