### PR TITLE
perf(DEE-44): native async fiqh subgraph + async /references and /hik…

### DIFF
--- a/agents/core/chat_agent.py
+++ b/agents/core/chat_agent.py
@@ -106,11 +106,9 @@ class ChatAgent:
     async def _fiqh_classification_node(self, state: ChatState) -> dict:
         logger.debug("Fiqh classification started", extra={"correlation_id": correlation_id_ctx.get()})
         try:
-            from modules.fiqh.classifier import classify_fiqh_query
+            from modules.fiqh.classifier import aclassify_fiqh_query
 
-            # classify_fiqh_query is sync (LLM .invoke). Phase 5 (DEE-44) makes
-            # the fiqh module natively async; until then offload to a thread.
-            category = await asyncio.to_thread(classify_fiqh_query, state["user_query"])
+            category = await aclassify_fiqh_query(state["user_query"])
             is_fiqh = category.startswith("VALID_")
             logger.debug("Fiqh classification complete", extra={"correlation_id": correlation_id_ctx.get(), "fiqh_category": category, "is_fiqh": is_fiqh})
             return {
@@ -313,27 +311,23 @@ Generate a comprehensive, accurate response that directly addresses the user's q
         Projects ChatState -> FiqhState input, invokes sub-graph, maps output -> ChatState delta.
         Uses Pattern 1 (node wrapper) because ChatState and FiqhState share no keys.
 
-        The fiqh sub-graph nodes are still sync (LLM .invoke). Phase 5 (DEE-44)
-        converts them to async and lets us swap to fiqh_subgraph.ainvoke; until
-        then offload the whole subgraph call to a thread so it doesn't block
-        the parent graph's event loop for the 10-15s subgraph runtime.
+        DEE-44 made every fiqh sub-graph node `async def`, so the whole 10-15s
+        subgraph run now drives via `.ainvoke` and yields between LLM calls
+        instead of blocking the executor.
         """
         logger.debug("Invoking FAIR-RAG sub-graph", extra={"correlation_id": correlation_id_ctx.get()})
         from agents.fiqh.fiqh_graph import fiqh_subgraph
 
         try:
-            result = await asyncio.to_thread(
-                fiqh_subgraph.invoke,
-                {
-                    "query": state["user_query"],
-                    "iteration": 0,
-                    "accumulated_docs": [],
-                    "prior_queries": [],
-                    "sea_result": None,
-                    "verdict": "INSUFFICIENT",
-                    "status_events": [],
-                },
-            )
+            result = await fiqh_subgraph.ainvoke({
+                "query": state["user_query"],
+                "iteration": 0,
+                "accumulated_docs": [],
+                "prior_queries": [],
+                "sea_result": None,
+                "verdict": "INSUFFICIENT",
+                "status_events": [],
+            })
             fiqh_filtered_docs = result.get("accumulated_docs", [])
             fiqh_sea_result = result.get("sea_result")
             status_events = result.get("status_events", [])

--- a/agents/fiqh/fiqh_graph.py
+++ b/agents/fiqh/fiqh_graph.py
@@ -23,13 +23,13 @@ logger = logging.getLogger(__name__)
 # Node functions
 # --------------------------------------------------------------------------- #
 
-def _decompose_node(state: FiqhState) -> dict:
+async def _decompose_node(state: FiqhState) -> dict:
     """Decompose original query into 1-4 keyword-rich sub-queries for retrieval."""
-    from modules.fiqh.decomposer import decompose_query
+    from modules.fiqh.decomposer import adecompose_query
 
     new_event = {"step": "fiqh_decompose", "message": "Decomposing fiqh query..."}
     try:
-        sub_queries = decompose_query(state["query"])
+        sub_queries = await adecompose_query(state["query"])
         logger.info("Fiqh query decomposed", extra={
             "correlation_id": correlation_id_ctx.get(),
         })
@@ -52,9 +52,9 @@ def _decompose_node(state: FiqhState) -> dict:
     }
 
 
-def _retrieve_node(state: FiqhState) -> dict:
+async def _retrieve_node(state: FiqhState) -> dict:
     """Retrieve fiqh documents for the latest query in prior_queries."""
-    from modules.fiqh.retriever import retrieve_fiqh_documents
+    from modules.fiqh.retriever import aretrieve_fiqh_documents
 
     iteration = state["iteration"] + 1
     new_event = {"step": "fiqh_retrieve", "message": f"Retrieving fiqh documents (iteration {iteration})..."}
@@ -63,7 +63,7 @@ def _retrieve_node(state: FiqhState) -> dict:
     current_query = state["prior_queries"][-1] if state["prior_queries"] else state["query"]
 
     try:
-        new_docs = retrieve_fiqh_documents(current_query)
+        new_docs = await aretrieve_fiqh_documents(current_query)
         if len(new_docs) == 0:
             logger.warning("Fiqh retrieval returned zero documents", extra={
                 "correlation_id": correlation_id_ctx.get(),
@@ -99,13 +99,13 @@ def _retrieve_node(state: FiqhState) -> dict:
     }
 
 
-def _filter_node(state: FiqhState) -> dict:
+async def _filter_node(state: FiqhState) -> dict:
     """Filter accumulated docs to keep relevant evidence (inclusive bias)."""
-    from modules.fiqh.filter import filter_evidence
+    from modules.fiqh.filter import afilter_evidence
 
     new_event = {"step": "fiqh_filter", "message": "Filtering fiqh evidence..."}
     try:
-        filtered = filter_evidence(state["query"], state["accumulated_docs"])
+        filtered = await afilter_evidence(state["query"], state["accumulated_docs"])
         if len(filtered) == 0:
             logger.warning("Fiqh evidence filter removed all documents", extra={
                 "correlation_id": correlation_id_ctx.get(),
@@ -132,13 +132,13 @@ def _filter_node(state: FiqhState) -> dict:
     }
 
 
-def _assess_node(state: FiqhState) -> dict:
+async def _assess_node(state: FiqhState) -> dict:
     """Run Structured Evidence Assessment (SEA) against accumulated docs."""
-    from modules.fiqh.sea import assess_evidence, SEAResult
+    from modules.fiqh.sea import aassess_evidence, SEAResult
 
     new_event = {"step": "fiqh_assess", "message": "Assessing evidence sufficiency..."}
     try:
-        sea_result = assess_evidence(state["query"], state["accumulated_docs"])
+        sea_result = await aassess_evidence(state["query"], state["accumulated_docs"])
         verdict = sea_result.verdict
         logger.info("Fiqh SEA assessment complete", extra={
             "correlation_id": correlation_id_ctx.get(),
@@ -167,13 +167,13 @@ def _assess_node(state: FiqhState) -> dict:
     }
 
 
-def _refine_node(state: FiqhState) -> dict:
+async def _refine_node(state: FiqhState) -> dict:
     """Generate targeted refinement queries from confirmed facts and gaps."""
-    from modules.fiqh.refiner import refine_query
+    from modules.fiqh.refiner import arefine_query
 
     new_event = {"step": "fiqh_refine", "message": "Refining query for next retrieval iteration..."}
     try:
-        refinements = refine_query(
+        refinements = await arefine_query(
             original_query=state["query"],
             sea_result=state["sea_result"],
             prior_queries=state["prior_queries"],

--- a/api/hikmah.py
+++ b/api/hikmah.py
@@ -71,8 +71,8 @@ async def chat_pipeline_stream_ep(
                 "lesson_name": request.lesson_name,
             },
         )
-        # Returns a StreamingResponse from the pipeline
-        return pipeline.hikmah_elaboration_pipeline_streaming(
+        # Returns a StreamingResponse from the now-async pipeline (DEE-44)
+        return await pipeline.hikmah_elaboration_pipeline_streaming(
             selected_text=request.selected_text,
             context_text=request.context_text,
             hikmah_tree_name=request.hikmah_tree_name,

--- a/api/reference.py
+++ b/api/reference.py
@@ -38,7 +38,7 @@ async def references_pipeline(
         raise HTTPException(status_code=400, detail="Please provide an appropriate query.")
 
     try:
-        results = pipeline.references_pipeline(user_query, sect, limit)
+        results = await pipeline.references_pipeline(user_query, sect, limit)
         logger.info(
             "References request completed",
             extra={"correlation_id": corr_id, "endpoint": "/references"},

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -1,14 +1,17 @@
+import asyncio
+from itertools import chain
+import json
+
+from fastapi.responses import StreamingResponse
+
+from core import utils
+from core.config import REFERENCE_FETCH_COUNT
 from modules.classification import classifier
 from modules.embedding import embedder
 from modules.enhancement import enhancer
 from modules.generation import generator, stream_generator
 from modules.retrieval import retriever
-from fastapi.responses import StreamingResponse
 from modules.translation import translator
-from core import utils
-from itertools import chain
-from core.config import REFERENCE_FETCH_COUNT
-import json
 
 # Not updated for memory persistence yet
 def chat_pipeline(user_query: str, session_id: str):
@@ -82,36 +85,43 @@ def chat_pipeline_streaming(user_query: str, session_id: str, target_language: s
 
 
 
-def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT):
-    # # Step 1: Classify query (fiqh or non-fiqh)
-    is_non_islamic = classifier.classify_non_islamic_query(user_query)
+async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT):
+    """Async references pipeline (DEE-44). Uses native `aclassify_*`,
+    `aenhance_query`, and `aretrieve_*` so the route doesn't block the event
+    loop on classification → enhancement → retrieval → ranking."""
+    is_non_islamic = await classifier.aclassify_non_islamic_query(user_query)
     if is_non_islamic:
         return "This question is not related to the domain of Islamic education. Please ask relevant questions."
-    
-    # Step 2: Enhance query
-    enhanced_query = enhancer.enhance_query(user_query)
 
-    # Step 3: Retrieve relevant documents from Pinecone with custom limit
-    results = {}
+    enhanced_query = await enhancer.aenhance_query(user_query)
+
+    results: dict = {}
+    fetches = []
     if sect in ["shia", "both"]:
-        results["shia"] = utils.format_references_as_json(retriever.retrieve_shia_documents(enhanced_query, limit))
+        fetches.append(("shia", retriever.aretrieve_shia_documents(enhanced_query, limit)))
     if sect in ["sunni", "both"]:
-        results["sunni"] = utils.format_references_as_json(retriever.retrieve_sunni_documents(enhanced_query, limit))
+        fetches.append(("sunni", retriever.aretrieve_sunni_documents(enhanced_query, limit)))
+
+    # Run shia + sunni retrievals concurrently when both are requested.
+    fetched = await asyncio.gather(*[fut for _, fut in fetches])
+    for (label, _), docs in zip(fetches, fetched):
+        results[label] = utils.format_references_as_json(docs)
 
     return results
 
-def hikmah_elaboration_pipeline_streaming(selected_text: str, context_text: str, hikmah_tree_name: str, lesson_name: str, lesson_summary: str, user_id: str = None):
 
-    # Step 1: Retrieve relevant documents from Pinecone based on context
-    relevant_shia_docs = retriever.retrieve_shia_documents(context_text, 4)
+async def hikmah_elaboration_pipeline_streaming(selected_text: str, context_text: str, hikmah_tree_name: str, lesson_name: str, lesson_summary: str, user_id: str = None):
+    """Async hikmah elaboration streaming pipeline (DEE-44)."""
+    relevant_shia_docs = await retriever.aretrieve_shia_documents(context_text, 4)
 
-    all_relevant_docs = relevant_shia_docs
-
-    # Step 2: Stream the AI response from the LLM
-    response_generator = stream_generator.generate_elaboration_response_stream(
-        selected_text, context_text, hikmah_tree_name, lesson_name, 
-        lesson_summary, all_relevant_docs, user_id=user_id
+    response_generator = stream_generator.agenerate_elaboration_response_stream(
+        selected_text,
+        context_text,
+        hikmah_tree_name,
+        lesson_name,
+        lesson_summary,
+        relevant_shia_docs,
+        user_id=user_id,
     )
 
-    # Return a StreamingResponse with appropriate media type.
     return StreamingResponse(response_generator, media_type="text/event-stream")

--- a/documentation/async_baseline.md
+++ b/documentation/async_baseline.md
@@ -239,3 +239,36 @@ A speedup of 1.0 means full serialisation; the Phase 7 gate requires
 }
 ```
 
+## phase-5 async-fiqh-and-routes (DEE-44) — 2026-04-29T20:26:38+00:00
+
+- mode: `in-process`
+- n: 10
+- wall_clock_s: **0.5711**
+- p50_s / p95_s: 0.5608 / 0.562
+- throughput_rps: 17.5116
+- speedup_vs_serial: **13.1337**
+
+```json
+{
+  "label": "phase-5 async-fiqh-and-routes (DEE-44)",
+  "mode": "in-process",
+  "n": 10,
+  "stubs": {
+    "llm_sleep_s": 0.2,
+    "retrieval_sleep_s": 0.1,
+    "per_token_sleep_s": 0.05,
+    "expected_per_request_s": 0.75,
+    "expected_serial_wall_s": 7.5
+  },
+  "wall_clock_s": 0.5711,
+  "p50_s": 0.5608,
+  "p95_s": 0.562,
+  "min_s": 0.5567,
+  "max_s": 0.562,
+  "mean_s": 0.5593,
+  "throughput_rps": 17.5116,
+  "speedup_vs_serial": 13.1337,
+  "timestamp": "2026-04-29T20:26:38+00:00"
+}
+```
+

--- a/modules/fiqh/classifier.py
+++ b/modules/fiqh/classifier.py
@@ -65,11 +65,11 @@ _prompt = ChatPromptTemplate.from_messages([
 
 def classify_fiqh_query(query: str) -> str:
     """
-    Classifies a fiqh query into one of 6 categories.
-    Never raises — returns OUT_OF_SCOPE_FIQH on any error.
+    Sync variant kept for legacy callers. Prefer `aclassify_fiqh_query` from
+    inside an event loop (DEE-44).
 
-    Uses with_structured_output to reliably extract the category
-    regardless of Claude preamble text in the response.
+    Classifies a fiqh query into one of 6 categories. Never raises — returns
+    OUT_OF_SCOPE_FIQH on any error.
 
     Returns one of: VALID_OBVIOUS, VALID_SMALL, VALID_LARGE, VALID_REASONER,
                     OUT_OF_SCOPE_FIQH, UNETHICAL
@@ -78,6 +78,17 @@ def classify_fiqh_query(query: str) -> str:
         model = chat_models.get_classifier_model()
         structured_model = model.with_structured_output(FiqhCategory)
         result = structured_model.invoke(_prompt.format_messages(query=query))
+        return result.category
+    except Exception:
+        return "OUT_OF_SCOPE_FIQH"
+
+
+async def aclassify_fiqh_query(query: str) -> str:
+    """Native async variant of `classify_fiqh_query`."""
+    try:
+        model = chat_models.get_classifier_model()
+        structured_model = model.with_structured_output(FiqhCategory)
+        result = await structured_model.ainvoke(_prompt.format_messages(query=query))
         return result.category
     except Exception:
         return "OUT_OF_SCOPE_FIQH"

--- a/modules/fiqh/decomposer.py
+++ b/modules/fiqh/decomposer.py
@@ -44,9 +44,28 @@ _prompt = ChatPromptTemplate.from_messages([
 ])
 
 
+def _parse_subqueries(content: str, fallback_query: str) -> list[str]:
+    if content.startswith("```"):
+        parts = content.split("```")
+        content = parts[1] if len(parts) > 1 else content
+        if content.startswith("json"):
+            content = content[4:]
+        content = content.strip()
+    try:
+        sub_queries = json.loads(content)
+    except Exception:
+        return [fallback_query]
+    if not isinstance(sub_queries, list) or not sub_queries:
+        return [fallback_query]
+    return [str(q).strip() for q in sub_queries[:4] if str(q).strip()] or [fallback_query]
+
+
 def decompose_query(query: str) -> list[str]:
     """
-    Decomposes a fiqh query into 1-4 keyword-rich sub-queries using the configured LLM (SMALL_LLM).
+    Sync variant kept for legacy callers. Prefer `adecompose_query` from
+    inside an event loop (DEE-44).
+
+    Decomposes a fiqh query into 1-4 keyword-rich sub-queries.
     Falls back to [query] on any parse error or unexpected output.
 
     Returns:
@@ -55,17 +74,16 @@ def decompose_query(query: str) -> list[str]:
     try:
         model = chat_models.get_classifier_model()
         response = model.invoke(_prompt.format_messages(query=query))
-        content = response.content.strip()
-        # Strip markdown code fences if LLM wraps output
-        if content.startswith("```"):
-            parts = content.split("```")
-            content = parts[1] if len(parts) > 1 else content
-            if content.startswith("json"):
-                content = content[4:]
-            content = content.strip()
-        sub_queries = json.loads(content)
-        if not isinstance(sub_queries, list) or not sub_queries:
-            return [query]
-        return [str(q).strip() for q in sub_queries[:4] if str(q).strip()]
+        return _parse_subqueries(response.content.strip(), query)
+    except Exception:
+        return [query]
+
+
+async def adecompose_query(query: str) -> list[str]:
+    """Native async variant of `decompose_query`."""
+    try:
+        model = chat_models.get_classifier_model()
+        response = await model.ainvoke(_prompt.format_messages(query=query))
+        return _parse_subqueries(response.content.strip(), query)
     except Exception:
         return [query]

--- a/modules/fiqh/filter.py
+++ b/modules/fiqh/filter.py
@@ -48,18 +48,33 @@ def _format_evidence_with_ids(docs: list[dict]) -> str:
     return "\n\n".join(lines)
 
 
+def _resolve_filter_response(content: str, docs: list[dict]) -> list[dict]:
+    if content.startswith("```"):
+        parts = content.split("```")
+        content = parts[1] if len(parts) > 1 else content
+        if content.startswith("json"):
+            content = content[4:]
+        content = content.strip()
+    try:
+        chunk_ids_to_keep: list[str] = json.loads(content)
+    except Exception:
+        return docs  # fail open
+    if not isinstance(chunk_ids_to_keep, list) or not chunk_ids_to_keep:
+        logger.warning("[FIQH_FILTER] LLM returned empty keep list — keeping all %d docs", len(docs))
+        return docs
+    keep_set = {str(cid) for cid in chunk_ids_to_keep}
+    filtered = [doc for doc in docs if doc.get("chunk_id") in keep_set]
+    return filtered if filtered else docs
+
+
 def filter_evidence(query: str, docs: list[dict]) -> list[dict]:
     """
+    Sync variant kept for legacy callers. Prefer `afilter_evidence` from
+    inside an event loop (DEE-44).
+
     Filters retrieved evidence using a single batch LLM call.
     Inclusive bias — returns all docs on any error or if LLM returns empty list.
     Never raises.
-
-    Args:
-        query: The original fiqh query string
-        docs: List of doc dicts with chunk_id, metadata, page_content keys
-
-    Returns:
-        list[dict]: Subset of input docs to keep. Returns all docs on error.
     """
     if not docs:
         return []
@@ -69,25 +84,23 @@ def filter_evidence(query: str, docs: list[dict]) -> list[dict]:
             query=query,
             evidence=_format_evidence_with_ids(docs),
         ))
-        content = response.content.strip()
-        # Strip markdown code fences if LLM wraps output
-        if content.startswith("```"):
-            parts = content.split("```")
-            content = parts[1] if len(parts) > 1 else content
-            if content.startswith("json"):
-                content = content[4:]
-            content = content.strip()
-        chunk_ids_to_keep: list[str] = json.loads(content)
-        if not isinstance(chunk_ids_to_keep, list) or not chunk_ids_to_keep:
-            # Empty list = over-aggressive filtering — fail open, keep all
-            logger.warning("[FIQH_FILTER] LLM returned empty keep list — keeping all %d docs", len(docs))
-            return docs
-        keep_set = set(str(cid) for cid in chunk_ids_to_keep)
-        filtered = [doc for doc in docs if doc.get("chunk_id") in keep_set]
-        if not filtered:
-            # No known chunk_ids matched — fail open
-            return docs
-        return filtered
+        return _resolve_filter_response(response.content.strip(), docs)
     except Exception as e:
         logger.warning("[FIQH_FILTER] filter_evidence error, returning all docs: %s", e)
+        return docs
+
+
+async def afilter_evidence(query: str, docs: list[dict]) -> list[dict]:
+    """Native async variant of `filter_evidence`."""
+    if not docs:
+        return []
+    try:
+        model = chat_models.get_generator_model()
+        response = await model.ainvoke(_prompt.format_messages(
+            query=query,
+            evidence=_format_evidence_with_ids(docs),
+        ))
+        return _resolve_filter_response(response.content.strip(), docs)
+    except Exception as e:
+        logger.warning("[FIQH_FILTER] afilter_evidence error, returning all docs: %s", e)
         return docs

--- a/modules/fiqh/generator.py
+++ b/modules/fiqh/generator.py
@@ -84,6 +84,15 @@ def _build_references_section(text: str, docs: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _post_process_answer(answer_text: str, docs: list[dict], is_sufficient: bool) -> str:
+    references = _build_references_section(answer_text, docs)
+    full_answer = answer_text + references
+    if not is_sufficient:
+        full_answer += INSUFFICIENT_WARNING
+    full_answer += FATWA_DISCLAIMER
+    return full_answer
+
+
 def generate_answer(
     query: str,
     docs: list[dict],
@@ -91,19 +100,11 @@ def generate_answer(
     is_sufficient: bool,
 ) -> str:
     """
+    Sync variant kept for legacy callers. Prefer `agenerate_answer` from
+    inside an event loop (DEE-44).
+
     Generates a fiqh answer from retrieved evidence with inline [n] citations,
     a ## Sources section, and a mandatory fatwa disclaimer.
-    Appends insufficient-evidence warning when is_sufficient=False.
-    Never raises.
-
-    Args:
-        query: The original fiqh query string
-        docs: List of doc dicts (chunk_id, metadata, page_content) — same list used for citation numbering
-        sea_result: SEAResult from assess_evidence (used for context; verdict not re-checked here)
-        is_sufficient: True if SEA declared SUFFICIENT, False otherwise
-
-    Returns:
-        str: Complete response with citations, ## Sources, fatwa disclaimer, and optional warning.
     """
     try:
         model = chat_models.get_generator_model()
@@ -111,20 +112,7 @@ def generate_answer(
             query=query,
             evidence=_format_evidence(docs),
         ))
-        answer_text = response.content.strip()
-
-        # Post-process: build references section from [n] tokens in the response
-        references = _build_references_section(answer_text, docs)
-        full_answer = answer_text + references
-
-        # Append insufficient-evidence warning before disclaimer when evidence is incomplete
-        if not is_sufficient:
-            full_answer += INSUFFICIENT_WARNING
-
-        # Always append fatwa disclaimer (per D-20, AGEN-04)
-        full_answer += FATWA_DISCLAIMER
-
-        return full_answer
+        return _post_process_answer(response.content.strip(), docs, is_sufficient)
 
     except Exception as e:
         logger.error("[FIQH_GENERATOR] generate_answer error: %s", e)
@@ -134,3 +122,26 @@ def generate_answer(
             + FATWA_DISCLAIMER
         )
         return fallback
+
+
+async def agenerate_answer(
+    query: str,
+    docs: list[dict],
+    sea_result: SEAResult,
+    is_sufficient: bool,
+) -> str:
+    """Native async variant of `generate_answer`."""
+    try:
+        model = chat_models.get_generator_model()
+        response = await model.ainvoke(_prompt.format_messages(
+            query=query,
+            evidence=_format_evidence(docs),
+        ))
+        return _post_process_answer(response.content.strip(), docs, is_sufficient)
+    except Exception as e:
+        logger.error("[FIQH_GENERATOR] agenerate_answer error: %s", e)
+        return (
+            "I was unable to generate an answer from the retrieved evidence. "
+            "Please consult Sistani's official resources at sistani.org or contact his office directly."
+            + FATWA_DISCLAIMER
+        )

--- a/modules/fiqh/refiner.py
+++ b/modules/fiqh/refiner.py
@@ -50,50 +50,75 @@ Generate 1-4 new retrieval sub-queries targeting the gaps above."""),
 ])
 
 
+def _build_refine_messages(
+    original_query: str,
+    sea_result: SEAResult,
+    prior_queries: list[str],
+):
+    confirmed_facts_text = "\n".join(f"- {f}" for f in sea_result.confirmed_facts) or "(none yet)"
+    gaps_text = "\n".join(f"- {g}" for g in sea_result.gaps) or "(no specific gaps identified)"
+    prior_queries_text = "\n".join(f"- {q}" for q in prior_queries) or "(none)"
+    return _prompt.format_messages(
+        original_query=original_query,
+        confirmed_facts=confirmed_facts_text,
+        gaps=gaps_text,
+        prior_queries=prior_queries_text,
+    )
+
+
+def _parse_refinements(content: str, original_query: str) -> list[str]:
+    if content.startswith("```"):
+        parts = content.split("```")
+        content = parts[1] if len(parts) > 1 else content
+        if content.startswith("json"):
+            content = content[4:]
+        content = content.strip()
+    try:
+        new_queries = json.loads(content)
+    except Exception:
+        return [original_query]
+    if not isinstance(new_queries, list) or not new_queries:
+        return [original_query]
+    return [str(q).strip() for q in new_queries[:4] if str(q).strip()] or [original_query]
+
+
 def refine_query(
     original_query: str,
     sea_result: SEAResult,
     prior_queries: list[str] | None = None,
 ) -> list[str]:
     """
-    Generates 1-4 targeted refinement sub-queries based on SEA gaps and confirmed facts.
-    Falls back to [original_query] on any error.
-    Never raises.
+    Sync variant kept for legacy callers. Prefer `arefine_query` from inside
+    an event loop (DEE-44).
 
-    Args:
-        original_query: The original fiqh query string
-        sea_result: SEAResult from assess_evidence — provides confirmed_facts and gaps
-        prior_queries: List of queries already tried (to avoid repetition). Defaults to [].
-
-    Returns:
-        list[str]: 1-4 new sub-query strings. Never empty, never raises.
+    Generates 1-4 targeted refinement sub-queries based on SEA gaps and
+    confirmed facts. Falls back to [original_query] on any error.
     """
     if prior_queries is None:
         prior_queries = []
     try:
         model = chat_models.get_generator_model()
-        confirmed_facts_text = "\n".join(f"- {f}" for f in sea_result.confirmed_facts) or "(none yet)"
-        gaps_text = "\n".join(f"- {g}" for g in sea_result.gaps) or "(no specific gaps identified)"
-        prior_queries_text = "\n".join(f"- {q}" for q in prior_queries) or "(none)"
-
-        response = model.invoke(_prompt.format_messages(
-            original_query=original_query,
-            confirmed_facts=confirmed_facts_text,
-            gaps=gaps_text,
-            prior_queries=prior_queries_text,
-        ))
-        content = response.content.strip()
-        # Strip markdown code fences if LLM wraps output
-        if content.startswith("```"):
-            parts = content.split("```")
-            content = parts[1] if len(parts) > 1 else content
-            if content.startswith("json"):
-                content = content[4:]
-            content = content.strip()
-        new_queries = json.loads(content)
-        if not isinstance(new_queries, list) or not new_queries:
-            return [original_query]
-        return [str(q).strip() for q in new_queries[:4] if str(q).strip()]
+        response = model.invoke(_build_refine_messages(original_query, sea_result, prior_queries))
+        return _parse_refinements(response.content.strip(), original_query)
     except Exception as e:
         logger.warning("[FIQH_REFINER] refine_query error, falling back to original: %s", e)
+        return [original_query]
+
+
+async def arefine_query(
+    original_query: str,
+    sea_result: SEAResult,
+    prior_queries: list[str] | None = None,
+) -> list[str]:
+    """Native async variant of `refine_query`."""
+    if prior_queries is None:
+        prior_queries = []
+    try:
+        model = chat_models.get_generator_model()
+        response = await model.ainvoke(
+            _build_refine_messages(original_query, sea_result, prior_queries)
+        )
+        return _parse_refinements(response.content.strip(), original_query)
+    except Exception as e:
+        logger.warning("[FIQH_REFINER] arefine_query error, falling back to original: %s", e)
         return [original_query]

--- a/modules/fiqh/retriever.py
+++ b/modules/fiqh/retriever.py
@@ -12,6 +12,7 @@ Architecture:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import traceback
 from pathlib import Path
@@ -21,7 +22,7 @@ from pinecone_text.sparse import BM25Encoder
 from core.config import DEEN_FIQH_DENSE_INDEX_NAME, DEEN_FIQH_SPARSE_INDEX_NAME
 from core.vectorstore import _get_sparse_vectorstore
 from modules.embedding.embedder import getDenseEmbedder
-from modules.fiqh.decomposer import decompose_query
+from modules.fiqh.decomposer import adecompose_query, decompose_query
 
 logger = logging.getLogger(__name__)
 
@@ -137,21 +138,13 @@ def _retrieve_for_sub_query(sub_query: str) -> list[dict]:
 
 def retrieve_fiqh_documents(query: str) -> list[dict]:
     """
-    Public interface for Phase 3 evidence assessment.
+    Sync variant kept for legacy callers. Prefer `aretrieve_fiqh_documents`
+    from inside an event loop (DEE-44).
 
     Decomposes the query into sub-queries, retrieves top-5 per sub-query via
     hybrid dense+sparse search with RRF merging, deduplicates by chunk_id.
 
-    Args:
-        query: Original fiqh query string
-
-    Returns:
-        list[dict]: Up to 20 unique documents, each with:
-            - chunk_id (str): Pinecone vector ID (e.g. "ruling_0712_chunk0")
-            - metadata (dict): source_book, chapter, section, ruling_number, topic_tags, text_en
-            - page_content (str): The ruling text (same as metadata["text_en"])
-
-        Returns [] on total failure. Never raises.
+    Returns up to 20 unique documents on success; [] on total failure.
     """
     try:
         sub_queries = decompose_query(query)
@@ -165,4 +158,69 @@ def retrieve_fiqh_documents(query: str) -> list[dict]:
         return result[:20]
     except Exception as e:
         logger.error("[FIQH_RETRIEVER] retrieve_fiqh_documents error: %s", e)
+        return []
+
+
+async def _aretrieve_for_sub_query(sub_query: str) -> list[dict]:
+    """Async variant of `_retrieve_for_sub_query`. CPU-bound bits (dense
+    embedding via sentence-transformers, BM25 sparse encoding) and the sync
+    Pinecone v1 .query() call are offloaded to a thread until PineconeAsyncio
+    is adopted; the dense and sparse Pinecone calls fire concurrently."""
+    try:
+        # Dense embedding: HuggingFaceEmbeddings.aembed_query handles the
+        # CPU work via LangChain's executor.
+        dense_vec = await getDenseEmbedder().aembed_query(sub_query)
+        encoder = _get_bm25_encoder()
+        sparse_vec = await asyncio.to_thread(encoder.encode_queries, sub_query)
+
+        dense_index = _get_sparse_vectorstore(DEEN_FIQH_DENSE_INDEX_NAME)
+        sparse_index = _get_sparse_vectorstore(DEEN_FIQH_SPARSE_INDEX_NAME)
+
+        dense_response, sparse_response = await asyncio.gather(
+            asyncio.to_thread(
+                dense_index.query,
+                vector=dense_vec,
+                top_k=20,
+                include_metadata=True,
+                namespace="ns1",
+            ),
+            asyncio.to_thread(
+                sparse_index.query,
+                sparse_vector=sparse_vec,
+                top_k=20,
+                include_metadata=True,
+                namespace="ns1",
+            ),
+        )
+        dense_matches = dense_response.matches if hasattr(dense_response, "matches") else \
+                        dense_response.get("matches", [])
+        sparse_matches = sparse_response.matches if hasattr(sparse_response, "matches") else \
+                         sparse_response.get("matches", [])
+
+        return _rrf_merge(dense_matches, sparse_matches, k=60, top_n=5)
+    except Exception as e:
+        logger.error("[FIQH_RETRIEVER] async sub-query retrieval error: %s\n%s", e, traceback.format_exc())
+        return []
+
+
+async def aretrieve_fiqh_documents(query: str) -> list[dict]:
+    """Native async variant of `retrieve_fiqh_documents`. Sub-queries are
+    decomposed once via `adecompose_query`, then per-sub-query retrievals run
+    concurrently via `asyncio.gather` — a 4-sub-query decomposition that
+    previously paid 4× round-trip latency now pays ~1×."""
+    try:
+        sub_queries = await adecompose_query(query)
+        per_sub_results = await asyncio.gather(
+            *[_aretrieve_for_sub_query(sq) for sq in sub_queries]
+        )
+        seen: set[str] = set()
+        result: list[dict] = []
+        for batch in per_sub_results:
+            for doc in batch:
+                if doc["chunk_id"] not in seen:
+                    seen.add(doc["chunk_id"])
+                    result.append(doc)
+        return result[:20]
+    except Exception as e:
+        logger.error("[FIQH_RETRIEVER] aretrieve_fiqh_documents error: %s", e)
         return []

--- a/modules/fiqh/sea.py
+++ b/modules/fiqh/sea.py
@@ -65,36 +65,49 @@ def _format_evidence(docs: list[dict]) -> str:
     return "\n\n".join(lines)
 
 
+def _insufficient_fallback(query: str) -> SEAResult:
+    return SEAResult(
+        findings=[],
+        verdict="INSUFFICIENT",
+        confirmed_facts=[],
+        gaps=[query],
+    )
+
+
 def assess_evidence(query: str, docs: list[dict]) -> SEAResult:
     """
+    Sync variant kept for legacy callers. Prefer `aassess_evidence` from
+    inside an event loop (DEE-44).
+
     Deconstructs the query into required findings, checks each against evidence,
     returns a structured sufficiency verdict with confirmed facts and gaps.
     Never raises — returns INSUFFICIENT fallback on any error.
-
-    Args:
-        query: The original fiqh query string
-        docs: List of doc dicts with chunk_id, metadata, page_content keys
-
-    Returns:
-        SEAResult: Structured assessment with findings, verdict, confirmed_facts, gaps.
-                   Returns fallback SEAResult(findings=[], verdict="INSUFFICIENT",
-                   confirmed_facts=[], gaps=[query]) on any error.
     """
     try:
         model = chat_models.get_classifier_model()
         structured_model = model.with_structured_output(SEAResult)
-        result = structured_model.invoke(
+        return structured_model.invoke(
             _prompt.format_messages(
                 query=query,
                 evidence=_format_evidence(docs),
             )
         )
-        return result
     except Exception as e:
         logger.warning("[FIQH_SEA] assess_evidence error, returning INSUFFICIENT fallback: %s", e)
-        return SEAResult(
-            findings=[],
-            verdict="INSUFFICIENT",
-            confirmed_facts=[],
-            gaps=[query],
+        return _insufficient_fallback(query)
+
+
+async def aassess_evidence(query: str, docs: list[dict]) -> SEAResult:
+    """Native async variant of `assess_evidence`."""
+    try:
+        model = chat_models.get_classifier_model()
+        structured_model = model.with_structured_output(SEAResult)
+        return await structured_model.ainvoke(
+            _prompt.format_messages(
+                query=query,
+                evidence=_format_evidence(docs),
+            )
         )
+    except Exception as e:
+        logger.warning("[FIQH_SEA] aassess_evidence error, returning INSUFFICIENT fallback: %s", e)
+        return _insufficient_fallback(query)

--- a/modules/generation/stream_generator.py
+++ b/modules/generation/stream_generator.py
@@ -41,11 +41,60 @@ def generate_response_stream(query: str, retrieved_docs: list, session_id: str, 
     hist = make_history(session_id)
     trim_history(hist)
 
+def _build_elaboration_chain():
+    chat_model = chat_models.get_generator_model()
+    prompt = prompt_templates.hikmah_elaboration_prompt_template
+    return prompt | chat_model
+
+
+def _elaboration_chain_input(
+    selected_text: str,
+    context_text: str,
+    hikmah_tree_name: str,
+    lesson_name: str,
+    lesson_summary: str,
+    retrieved_docs: list,
+) -> dict:
+    references = utils.compact_format_references(retrieved_docs=retrieved_docs)
+    return {
+        "selected_text": selected_text,
+        "context_text": context_text,
+        "hikmah_tree_name": hikmah_tree_name,
+        "lesson_name": lesson_name,
+        "lesson_summary": lesson_summary,
+        "references": references,
+    }
+
+
+def _schedule_hikmah_memory_update(user_id: str, selected_text: str, hikmah_tree_name: str, lesson_name: str):
+    """Fire-and-forget memory update. Runs in a daemon thread with its own
+    event loop so it never blocks the response stream and is independent of
+    whether the caller is sync or async."""
+    memory_logger.info(
+        "Scheduling hikmah memory update",
+        extra={
+            "user_id": user_id,
+            "selected_text_len": len(selected_text or ""),
+            "selected_text_preview": (selected_text or "")[:120],
+            "hikmah_tree_name": hikmah_tree_name,
+            "lesson_name": lesson_name,
+            "context_text_passed": False,
+            "lesson_summary_passed": False,
+        },
+    )
+    thread = threading.Thread(
+        target=_run_memory_update_sync,
+        args=(user_id, selected_text, hikmah_tree_name, lesson_name),
+        daemon=True,
+    )
+    thread.start()
+    print(f"🧠 Memory agent thread started for user {user_id}")
+
+
 def generate_elaboration_response_stream(selected_text: str, context_text: str, hikmah_tree_name: str, lesson_name: str, lesson_summary: str, retrieved_docs: list, user_id: Optional[str] = None):
     """
-    Generates a streaming response using the chat model.
-    Yields chunks of text as they are generated.
-    If user_id is provided, triggers memory agent after streaming completes.
+    Sync streaming generator kept for legacy callers. Prefer
+    `agenerate_elaboration_response_stream` from inside an event loop (DEE-44).
     """
     print("INSIDE generate_elaboration_response_stream")
     logger.info(
@@ -60,53 +109,53 @@ def generate_elaboration_response_stream(selected_text: str, context_text: str, 
             "lesson_name": lesson_name,
         },
     )
-    # Format retrieved references
-    references = utils.compact_format_references(retrieved_docs=retrieved_docs)
+    chain = _build_elaboration_chain()
+    chain_input = _elaboration_chain_input(
+        selected_text, context_text, hikmah_tree_name, lesson_name, lesson_summary, retrieved_docs
+    )
 
-    chat_model = chat_models.get_generator_model()
+    for chunk in chain.stream(chain_input):
+        yield getattr(chunk, "content", str(chunk) if chunk is not None else "")
 
-    prompt = prompt_templates.hikmah_elaboration_prompt_template
-    chain = prompt | chat_model
-
-    # Capture AI response for memory agent (if user_id provided)
-    ai_response_chunks = []
-
-    # Stream chunks to caller
-    for chunk in chain.stream(
-        {"selected_text": selected_text, "context_text": context_text, "hikmah_tree_name": hikmah_tree_name, "lesson_name": lesson_name, "lesson_summary": lesson_summary, "references": references}):
-        # `chunk` is typically an AIMessageChunk or string
-        content = getattr(chunk, "content", str(chunk) if chunk is not None else "")
-        
-        # Capture for memory agent
-        if user_id:
-            ai_response_chunks.append(content)
-        
-        yield content
-    
-    # After streaming completes, trigger memory agent if user_id provided
     if user_id:
-        # Fire and forget: Run memory update in separate thread
-        # Note: We don't pass ai_response or full context_text to avoid overwhelming the agent
-        # The selected_text + lesson/tree name is the key signal
-        memory_logger.info(
-            "Scheduling hikmah memory update",
-            extra={
-                "user_id": user_id,
-                "selected_text_len": len(selected_text or ""),
-                "selected_text_preview": (selected_text or "")[:120],
-                "hikmah_tree_name": hikmah_tree_name,
-                "lesson_name": lesson_name,
-                "context_text_passed": False,
-                "lesson_summary_passed": False,
-            },
-        )
-        thread = threading.Thread(
-            target=_run_memory_update_sync,
-            args=(user_id, selected_text, hikmah_tree_name, lesson_name),
-            daemon=True  # Daemon thread won't prevent shutdown
-        )
-        thread.start()
-        print(f"🧠 Memory agent thread started for user {user_id}")
+        _schedule_hikmah_memory_update(user_id, selected_text, hikmah_tree_name, lesson_name)
+
+
+async def agenerate_elaboration_response_stream(
+    selected_text: str,
+    context_text: str,
+    hikmah_tree_name: str,
+    lesson_name: str,
+    lesson_summary: str,
+    retrieved_docs: list,
+    user_id: Optional[str] = None,
+):
+    """Native async generator. Uses `chain.astream` so the worker can serve
+    other concurrent SSE streams while this one waits on Anthropic tokens.
+    The fire-and-forget memory thread is unchanged — it doesn't share a loop
+    with the caller anyway."""
+    logger.info(
+        "Starting hikmah elaboration stream (async)",
+        extra={
+            "user_id": user_id,
+            "selected_text_len": len(selected_text or ""),
+            "selected_text_preview": (selected_text or "")[:120],
+            "context_text_len": len(context_text or ""),
+            "lesson_summary_len": len(lesson_summary or ""),
+            "hikmah_tree_name": hikmah_tree_name,
+            "lesson_name": lesson_name,
+        },
+    )
+    chain = _build_elaboration_chain()
+    chain_input = _elaboration_chain_input(
+        selected_text, context_text, hikmah_tree_name, lesson_name, lesson_summary, retrieved_docs
+    )
+
+    async for chunk in chain.astream(chain_input):
+        yield getattr(chunk, "content", str(chunk) if chunk is not None else "")
+
+    if user_id:
+        _schedule_hikmah_memory_update(user_id, selected_text, hikmah_tree_name, lesson_name)
 
 
 def _run_memory_update_sync(user_id: str, selected_text: str,

--- a/tests/conftest_async_stubs.py
+++ b/tests/conftest_async_stubs.py
@@ -287,8 +287,17 @@ def install_pipeline_stubs(cfg: Optional[StubConfig] = None):
         retriever_mod.aretrieve_quran_documents = _astub_retrieve_quran
 
     # --- Fiqh classifier stub (skip the fiqh sub-graph entirely) ------------
+    # ChatAgent._fiqh_classification_node now awaits `aclassify_fiqh_query`
+    # directly (DEE-44); patch both for forward/backward compat.
     original_classify_fiqh = fiqh_classifier_mod.classify_fiqh_query
+    original_aclassify_fiqh = getattr(fiqh_classifier_mod, "aclassify_fiqh_query", None)
     fiqh_classifier_mod.classify_fiqh_query = lambda query: "OUT_OF_SCOPE_FIQH"
+
+    async def _astub_classify_fiqh(query):
+        return "OUT_OF_SCOPE_FIQH"
+
+    if original_aclassify_fiqh is not None:
+        fiqh_classifier_mod.aclassify_fiqh_query = _astub_classify_fiqh
 
     try:
         yield cfg
@@ -303,6 +312,8 @@ def install_pipeline_stubs(cfg: Optional[StubConfig] = None):
             retriever_mod.aretrieve_sunni_documents = originals["asunni"]
             retriever_mod.aretrieve_quran_documents = originals["aquran"]
         fiqh_classifier_mod.classify_fiqh_query = original_classify_fiqh
+        if original_aclassify_fiqh is not None:
+            fiqh_classifier_mod.aclassify_fiqh_query = original_aclassify_fiqh
 
 
 # --- Concurrency harness ---------------------------------------------------

--- a/tests/test_concurrency_baseline.py
+++ b/tests/test_concurrency_baseline.py
@@ -33,7 +33,7 @@ from scripts.loadtest_agentic import _emit_snapshot, _run_in_process, parse_args
 
 _BASELINE_PATH = Path(__file__).resolve().parent.parent / "documentation" / "async_baseline.md"
 
-_DEFAULT_LABEL = "phase-4 async-redis (DEE-43)"
+_DEFAULT_LABEL = "phase-5 async-fiqh-and-routes (DEE-44)"
 
 
 def _build_args(n: int, label: str):

--- a/tests/test_fiqh_async.py
+++ b/tests/test_fiqh_async.py
@@ -1,0 +1,100 @@
+"""
+Phase 5 (DEE-44) regression suite for the fiqh subsystem.
+
+Pin three properties:
+
+1. Every node in `agents/fiqh/fiqh_graph.py` is `async def`. ToolNode-style
+   wiring won't fire here, but mixing sync and async nodes in a LangGraph
+   compiled with `.ainvoke` produces hard-to-debug warnings — cheaper to
+   assert at the type level than to chase a regression in production.
+
+2. Every public `modules/fiqh/*` LLM-touching function exposes an `a`-prefixed
+   async variant. New code must call the async variant from inside an event
+   loop; the sync variant is kept only for legacy /chat/ and /references
+   callers (until DEE-45 retires them).
+
+3. `aretrieve_fiqh_documents` fans out per-sub-query retrievals via
+   `asyncio.gather`. With a stubbed `_aretrieve_for_sub_query` that sleeps
+   200ms, a 4-sub-query decomposition must complete in well under
+   4 × 200ms = 800ms — proves the gather is real, not sequential awaits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_every_fiqh_subgraph_node_is_async():
+    from agents.fiqh import fiqh_graph
+
+    node_names = [
+        "_decompose_node",
+        "_retrieve_node",
+        "_filter_node",
+        "_assess_node",
+        "_refine_node",
+    ]
+    for name in node_names:
+        node_fn = getattr(fiqh_graph, name)
+        assert asyncio.iscoroutinefunction(node_fn), (
+            f"agents/fiqh/fiqh_graph.{name} must be `async def` after DEE-44"
+        )
+
+
+@pytest.mark.asyncio
+async def test_fiqh_modules_expose_async_variants():
+    """If any of these go missing, callers that dropped the to_thread wrapper
+    in DEE-44 will start raising AttributeError at runtime. Prefer a clean
+    test failure here."""
+    from modules.fiqh import classifier as fc
+    from modules.fiqh import decomposer
+    from modules.fiqh import filter as fiqh_filter
+    from modules.fiqh import generator as fiqh_generator
+    from modules.fiqh import refiner
+    from modules.fiqh import retriever as fiqh_retriever
+    from modules.fiqh import sea
+
+    expected = {
+        fc: "aclassify_fiqh_query",
+        decomposer: "adecompose_query",
+        fiqh_filter: "afilter_evidence",
+        fiqh_generator: "agenerate_answer",
+        refiner: "arefine_query",
+        fiqh_retriever: "aretrieve_fiqh_documents",
+        sea: "aassess_evidence",
+    }
+    for module, attr in expected.items():
+        fn = getattr(module, attr, None)
+        assert asyncio.iscoroutinefunction(fn), (
+            f"{module.__name__}.{attr} must exist as `async def` after DEE-44"
+        )
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_fiqh_documents_fans_out_concurrently(monkeypatch):
+    """Stub the per-sub-query retriever to sleep, then prove the public
+    `aretrieve_fiqh_documents` runs the 4 sub-query retrievals concurrently
+    via asyncio.gather (wall ~200ms) instead of sequentially (~800ms)."""
+    from modules.fiqh import retriever as fiqh_retriever
+
+    async def _astub_decompose(query: str):
+        return [f"sq{i}" for i in range(4)]
+
+    async def _astub_per_subquery(sub_query: str):
+        await asyncio.sleep(0.2)
+        return [{"chunk_id": f"{sub_query}-doc"}]
+
+    monkeypatch.setattr(fiqh_retriever, "adecompose_query", _astub_decompose)
+    monkeypatch.setattr(fiqh_retriever, "_aretrieve_for_sub_query", _astub_per_subquery)
+
+    started = time.perf_counter()
+    docs = await fiqh_retriever.aretrieve_fiqh_documents("anything")
+    elapsed = time.perf_counter() - started
+
+    # 4 × 200ms sequential ≈ 800ms; concurrent should be ~200ms + small overhead.
+    assert elapsed < 0.5, f"sub-query retrieval serialised: wall={elapsed:.3f}s for 4 sub-queries"
+    assert {d["chunk_id"] for d in docs} == {f"sq{i}-doc" for i in range(4)}


### PR DESCRIPTION
…mah/elaborate

Phase 5 of DEE-36. Three things in one PR:

(1) Native async fiqh subgraph
- modules/fiqh/{classifier,decomposer,filter,sea,refiner,generator}.py: add a-prefixed async variants (aclassify_fiqh_query, adecompose_query, afilter_evidence, aassess_evidence, arefine_query, agenerate_answer) using model.ainvoke / structured_model.ainvoke. Sync versions kept for legacy /chat/ and /references callers.
- modules/fiqh/retriever.py: aretrieve_fiqh_documents + _aretrieve_for_sub_query. Dense embedding via aembed_query, BM25 sparse encoding in to_thread, dense+sparse Pinecone fired concurrently per sub-query via asyncio.gather, and the per-sub-query retrievals run concurrently across all decomposed sub-queries.
- agents/fiqh/fiqh_graph.py: every node (_decompose, _retrieve, _filter, _assess, _refine) → async def using the new async module variants.
- agents/core/chat_agent.py: _fiqh_classification_node now awaits aclassify_fiqh_query directly; _call_fiqh_subgraph_node awaits fiqh_subgraph.ainvoke directly. The Phase-2 asyncio.to_thread wrappers are gone — the 10-15s subgraph run no longer blocks the executor pool, it cooperatively yields between LLM calls.

(2) /references route async-ified
- core/pipeline.py:references_pipeline → async def, awaits aclassify_non_islamic_query, aenhance_query, aretrieve_*; shia+sunni retrievals fire concurrently via asyncio.gather when sect=both.
- api/reference.py awaits the now-async pipeline fn.

(3) /hikmah/elaborate route async-ified
- modules/generation/stream_generator.py: agenerate_elaboration_response_stream — async generator using chain.astream so the worker can serve other concurrent SSE streams while waiting on Anthropic tokens. Sync variant kept for legacy callers. Memory-update background thread is unchanged (it owns its own loop).
- core/pipeline.py:hikmah_elaboration_pipeline_streaming → async def, awaits aretrieve_shia_documents and returns StreamingResponse over the async generator.
- api/hikmah.py:chat_pipeline_stream_ep awaits the now-async pipeline fn.

tests/conftest_async_stubs.py: also patch aclassify_fiqh_query so existing in-process loadtests keep skipping the fiqh path.

tests/test_fiqh_async.py — new
- Every fiqh subgraph node is async (regression guard).
- Every fiqh module exposes the expected a-prefixed coroutine.
- aretrieve_fiqh_documents fans out per-sub-query retrievals via asyncio.gather (4 sub-queries × 200ms stub completes in ~200ms wall, not 800ms) — proves the gather is real.

Phase 5 numbers (N=10, agentic streaming with stub fiqh classifier set to OUT_OF_SCOPE_FIQH so the subgraph doesn't run on this path):
  wall_clock     0.61s → 0.57s
  p95            0.59s → 0.56s
  speedup_vs_serial 12.26x → 13.13x
The real wins land on /hikmah/elaborate and on actual fiqh queries
(10-15s per request previously serialised on the executor; now
cooperatively interleaves) — those paths aren't exercised by the in-process
agentic loadtest, but the new test_fiqh_async asserts the structural
property directly.

Existing fiqh test suite (64 tests across decomposer, filter, sea, refiner, generator, retriever, classifier) remains 100% green — sync API preserved.