### PR TITLE
perf(DEE-45): async DB (asyncpg + AsyncSession) for chat persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,20 +65,23 @@ The AI pipeline flows: HTTP request → `api/` → `core/pipeline_langgraph.py` 
 ### Key environment variables
 
 ```
-OPENAI_API_KEY, LARGE_LLM, SMALL_LLM
+ANTHROPIC_API_KEY, LARGE_LLM, SMALL_LLM
 PINECONE_API_KEY, DEEN_DENSE_INDEX_NAME, DEEN_SPARSE_INDEX_NAME, QURAN_DENSE_INDEX_NAME
 REDIS_URL, REDIS_KEY_PREFIX, REDIS_TTL_SECONDS, REDIS_MAX_MESSAGES
 DATABASE_URL, ASYNC_DATABASE_URL
+SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 COGNITO_REGION, COGNITO_POOL_ID
 CORS_ALLOW_ORIGINS
 ENV (development/production)
 ```
 
-Current LLM defaults: `LARGE_LLM=gpt-4.1-2025-04-14`, `SMALL_LLM=gpt-4o-mini-2024-07-18`.
+Current LLM defaults: `LARGE_LLM=claude-sonnet-4-6`, `SMALL_LLM=claude-haiku-4-5-20251001`. Provider is Anthropic via `langchain-anthropic`; the `.ainvoke()` / `.astream()` interface is provider-agnostic, so the pipeline does not depend on Anthropic specifically.
 
 ### Agentic pipeline (LangGraph)
 
 `core/pipeline_langgraph.py` implements the active pipeline as a LangGraph graph. The agent uses 9 tools (across `agents/tools/`: 4 retrieval, 2 classification, 2 translation, 1 enhancement) bound to the LLM via `.bind_tools()`. Key early-exit conditions: `non_islamic` classification and `fiqh` routing — when fiqh is detected, control hands off to the FAIR-RAG subsystem (see below). When adding new agentic behavior, write tests around tool-selection outcomes and these early-exit paths.
+
+All graph nodes and bound tools are now natively async (DEE-41/DEE-42); `agent.astream()` is the streaming entry point and never blocks the event loop on LLM, Pinecone, or Redis I/O. Per-token streaming uses `chain.astream()` (DEE-40) inside an `async def` generator.
 
 ### Fiqh subsystem (FAIR-RAG)
 
@@ -93,11 +96,26 @@ The fiqh path is a separate, dedicated graph — not just a tool on the main age
 - `fair_rag.py` — `run_fair_rag(query)` is the synchronous entry point used outside LangGraph
 - `classifier.py` — fiqh-specific topical classification
 
+Fiqh subgraph nodes (`_decompose_node`, `_retrieve_node`, etc. in `agents/fiqh/fiqh_graph.py`) are now natively async (DEE-44); the `asyncio.to_thread` wrapper from Phase 2 has been removed. The main agent invokes the subgraph via `await fiqh_subgraph.ainvoke(...)`.
+
 Corpus ingestion lives in `scripts/ingest_fiqh.py` and populates separate Pinecone indices (do not reuse the main hadith/Quran indices). Fiqh tests are `tests/test_fiqh_*.py` covering each stage individually plus integration (`test_fiqh_integration.py`) and graph-level logging (`test_fiqh_graph_logging.py`). Honour the religious-sensitivity constraints from the Project section: never issue fatwas, always include disclaimers, refuse rather than speculate.
+
+### Async architecture (DEE-36)
+
+The streaming hot path is end-to-end async; see `documentation/async_baseline.md` for per-phase concurrency snapshots (3.45s → 0.57s wall-clock at N=10).
+
+- `core/pipeline_langgraph.py` uses `chain.astream()` end-to-end (DEE-40).
+- ChatAgent nodes and all 9 `@tool` functions are `async def` (DEE-41).
+- LLM modules + Pinecone retrieval are natively async — `aclassify_*`, `aenhance_query`, `atranslate_*`, `PineconeAsyncio.asimilarity_search_with_score` (DEE-42).
+- Redis chat history uses `AsyncRedisChatMessageHistory` from `core/memory.py` (DEE-43).
+- Fiqh subgraph and `/references`, `/hikmah/elaborate` routes are natively async (DEE-44).
+- Async DB (`asyncpg` + `AsyncSession`) is **not yet shipped** — DEE-45 in backlog. `db/session.py` (sync) is still the active path.
 
 ### Memory system
 
 Redis stores per-user conversation history (`REDIS_KEY_PREFIX` namespaced). `services/memory_service.py` and `services/consolidation_service.py` handle memory operations; `core/memory.py` provides low-level Redis access. Memory admin is exposed at `/admin/memory`.
+
+Redis access is fully async (DEE-43): `core/memory.py` exposes `amake_history(...)` returning a custom `AsyncRedisChatMessageHistory` wrapper that loads, appends, and trims via `redis.asyncio`. The wrapper is wire-compatible with `langchain-community`'s sync version, and the sync `make_history(...)` shim is retained only for legacy code paths.
 
 ### Database
 
@@ -304,7 +322,7 @@ An enhancement to the Deen Islamic education platform's chatbot agent that enabl
 - Returns `StreamingResponse` for streaming variant.
 - Defines the `ChatAgent` class: builds a `StateGraph(ChatState)` with 5 nodes and compiles it with `MemorySaver` checkpointing.
 - Graph nodes: `fiqh_classification`, `agent`, `tools`, `generate_response`, `check_early_exit`.
-- The LLM (`LARGE_LLM`, defaults to `gpt-4.1-2025-04-14`) is bound to 6 tools via `.bind_tools()`.
+- The LLM (`LARGE_LLM`, defaults to `claude-sonnet-4-6`) is bound to 9 tools via `.bind_tools()`.
 - Routing decisions (`_should_continue`, `_route_after_fiqh_check`) are pure functions over `ChatState`.
 - Loads conversation history from Redis via `core.memory.make_history()` at the start of each `invoke`/`astream` call.
 - `ChatState` is a `TypedDict` carrying all state through the graph.
@@ -367,10 +385,10 @@ An enhancement to the Deen Islamic education platform's chatbot agent that enabl
 ## Async vs Sync Patterns
 - **FastAPI route handlers** are `async def` throughout.
 - **Agentic pipeline streaming** (`chat_pipeline_streaming_agentic`) is fully async: `async for event in agent.astream(...)`, returns `StreamingResponse` with an `AsyncGenerator`.
-- **LangGraph graph execution** uses `compiled_graph.astream()` (async) and `compiled_graph.invoke()` (sync).
-- **LLM calls inside graph nodes** are synchronous (`llm.invoke()`, `chain.stream()`). The streaming token loop in `pipeline_langgraph.py` uses `chain.stream()` (sync iterator) inside an `async def` generator — this blocks the event loop briefly per iteration.
-- **Database access** uses synchronous SQLAlchemy (`db/session.py`, `psycopg2` driver). Async DB via `asyncpg` is configured (`ASYNC_DATABASE_URL`) but not yet actively used in routers.
-- **Redis** is accessed synchronously via `langchain_community.chat_message_histories.RedisChatMessageHistory`.
+- **LangGraph graph execution** uses `compiled_graph.astream()` (async) and `compiled_graph.ainvoke()` (async). The legacy sync `compiled_graph.invoke()` path is retained for the legacy pipeline only.
+- **LLM calls inside graph nodes** are async (`.ainvoke()`, `.astream()`). The streaming token loop in `pipeline_langgraph.py` uses `chain.astream()` inside an `async def` generator (DEE-40).
+- **Database access** uses synchronous SQLAlchemy (`db/session.py`, `psycopg2` driver). Async DB via `asyncpg` is configured (`ASYNC_DATABASE_URL`) but not yet actively used in routers — DEE-45 will migrate `chat_persistence_service.py` first.
+- **Redis** is accessed asynchronously via the in-house `AsyncRedisChatMessageHistory` wrapper backed by `redis.asyncio` (DEE-43); the sync `RedisChatMessageHistory` from `langchain_community` is kept only for legacy code paths.
 ## Early Exit Conditions
 ## Error Handling
 - **Global middleware** in `main.py` (`catch_exceptions_mw`) catches all unhandled exceptions, logs the traceback, and returns `{"detail": "internal_error"}` with HTTP 500.

--- a/api/chat.py
+++ b/api/chat.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from db.async_session import get_db_async
 from db.schemas.chat_history import SavedChatDetailResponse, SavedChatListResponse
-from db.session import get_db
 from models.JWTBearer import JWTAuthorizationCredentials
 from models.schemas import ChatRequest
 from core import pipeline
@@ -68,7 +68,7 @@ async def chat_pipeline_ep(
 async def chat_pipeline_stream_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db_async),
 ):
     """
     Streaming chat endpoint with Redis-backed memory.
@@ -93,12 +93,12 @@ async def chat_pipeline_stream_ep(
         runtime_session_id = session_id
 
         if user_id:
-            runtime_session_id = chat_persistence_service.hydrate_runtime_history_if_empty(
+            runtime_session_id = await chat_persistence_service.hydrate_runtime_history_if_empty(
                 db,
                 user_id=user_id,
                 session_id=session_id,
             )
-            chat_persistence_service.persist_user_message(
+            await chat_persistence_service.persist_user_message(
                 db,
                 user_id=user_id,
                 session_id=session_id,
@@ -129,7 +129,7 @@ async def chat_pipeline_stream_ep(
 async def chat_pipeline_agentic_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db_async),
 ):
     """
     Agentic streaming chat endpoint using LangGraph.
@@ -183,12 +183,12 @@ async def chat_pipeline_agentic_ep(
         )
         runtime_session_id = session_id
         if user_id:
-            runtime_session_id = chat_persistence_service.hydrate_runtime_history_if_empty(
+            runtime_session_id = await chat_persistence_service.hydrate_runtime_history_if_empty(
                 db,
                 user_id=user_id,
                 session_id=session_id,
             )
-            chat_persistence_service.persist_user_message(
+            await chat_persistence_service.persist_user_message(
                 db,
                 user_id=user_id,
                 session_id=session_id,
@@ -359,12 +359,12 @@ async def clear_session(
 @chat_router.get("/saved", response_model=SavedChatListResponse)
 async def list_saved_chats(
     credentials: JWTAuthorizationCredentials = Depends(auth),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db_async),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
     user_id = _require_user_id(credentials)
-    items, total = chat_persistence_service.list_sessions(
+    items, total = await chat_persistence_service.list_sessions(
         db,
         user_id=user_id,
         limit=limit,
@@ -382,12 +382,12 @@ async def list_saved_chats(
 async def get_saved_chat(
     session_id: str,
     credentials: JWTAuthorizationCredentials = Depends(auth),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db_async),
     limit: int = Query(200, ge=1, le=1000),
     offset: int = Query(0, ge=0),
 ):
     user_id = _require_user_id(credentials)
-    result = chat_persistence_service.get_session_with_messages(
+    result = await chat_persistence_service.get_session_with_messages(
         db,
         user_id=user_id,
         session_id=session_id,

--- a/db/async_session.py
+++ b/db/async_session.py
@@ -1,0 +1,43 @@
+from typing import AsyncIterator
+
+from sqlalchemy.engine import URL
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from .config import settings
+
+
+def _build_async_database_url() -> str:
+    return URL.create(
+        drivername="postgresql+asyncpg",
+        username=settings.DB_USER,
+        password=settings.DB_PASSWORD,
+        host=settings.DB_HOST,
+        port=settings.DB_PORT,
+        database=settings.DB_NAME,
+    ).render_as_string(hide_password=False)
+
+
+async_engine = create_async_engine(
+    _build_async_database_url(),
+    future=True,
+    pool_pre_ping=True,
+    echo=False,
+    # asyncpg's `ssl="require"` mirrors psycopg2's `sslmode=require` used by the
+    # sync engine in db/session.py — encrypt but skip cert chain verification.
+    # Supabase's CA isn't in the local Python trust store on Windows, so `ssl=True`
+    # (full verify) breaks local dev. Prod containers hit the same code path.
+    connect_args={"ssl": "require"},
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    bind=async_engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+    class_=AsyncSession,
+)
+
+
+async def get_db_async() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ annotated-types==0.7.0
 anthropic==0.92.0
 anyio==4.8.0
 asyncpg==0.30.0
+aiosqlite==0.20.0
 attrs==25.3.0
 certifi==2025.1.31
 cffi==1.17.1

--- a/services/chat_persistence_service.py
+++ b/services/chat_persistence_service.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime
 import json
 import re
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import AIMessage, HumanMessage
-from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.concurrency import iterate_in_threadpool
 
 from core.memory import amake_history, atrim_history, make_history, trim_history
@@ -104,22 +103,23 @@ def _touch_session(session_row: ChatSession) -> None:
     session_row.last_message_at = now
 
 
-def _get_session(db: Session, user_id: str, session_id: str) -> Optional[ChatSession]:
-    return (
-        db.query(ChatSession)
-        .filter(ChatSession.user_id == user_id, ChatSession.session_id == session_id)
-        .first()
+async def _get_session(db: AsyncSession, user_id: str, session_id: str) -> Optional[ChatSession]:
+    stmt = (
+        select(ChatSession)
+        .where(ChatSession.user_id == user_id, ChatSession.session_id == session_id)
     )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
 
 
-def get_or_create_session(
-    db: Session,
+async def get_or_create_session(
+    db: AsyncSession,
     *,
     user_id: str,
     session_id: str,
     first_query: str,
 ) -> ChatSession:
-    session_row = _get_session(db, user_id, session_id)
+    session_row = await _get_session(db, user_id, session_id)
     if session_row:
         return session_row
 
@@ -129,12 +129,12 @@ def get_or_create_session(
         title=derive_chat_title(first_query),
     )
     db.add(session_row)
-    db.flush()
+    await db.flush()
     return session_row
 
 
-def append_message(
-    db: Session,
+async def append_message(
+    db: AsyncSession,
     *,
     session_row: ChatSession,
     role: str,
@@ -150,32 +150,32 @@ def append_message(
     return message
 
 
-def persist_user_message(
-    db: Session,
+async def persist_user_message(
+    db: AsyncSession,
     *,
     user_id: str,
     session_id: str,
     user_query: str,
 ) -> ChatSession:
-    session_row = get_or_create_session(
+    session_row = await get_or_create_session(
         db,
         user_id=user_id,
         session_id=session_id,
         first_query=user_query,
     )
-    append_message(
+    await append_message(
         db,
         session_row=session_row,
         role="user",
         content=user_query,
     )
-    db.commit()
-    db.refresh(session_row)
+    await db.commit()
+    await db.refresh(session_row)
     return session_row
 
 
-def persist_assistant_message(
-    db: Session,
+async def persist_assistant_message(
+    db: AsyncSession,
     *,
     user_id: str,
     session_id: str,
@@ -185,43 +185,45 @@ def persist_assistant_message(
     if not cleaned_text:
         return None
 
-    session_row = _get_session(db, user_id, session_id)
+    session_row = await _get_session(db, user_id, session_id)
     if not session_row:
         return None
 
-    message = append_message(
+    message = await append_message(
         db,
         session_row=session_row,
         role="assistant",
         content=cleaned_text,
     )
-    db.commit()
+    await db.commit()
     return message
 
 
-def hydrate_runtime_history_if_empty(
-    db: Session,
+async def hydrate_runtime_history_if_empty(
+    db: AsyncSession,
     *,
     user_id: str,
     session_id: str,
 ) -> str:
+    """Async-native hydration: Redis check + Postgres backfill both run on the
+    event loop without `asyncio.to_thread` (DEE-45)."""
     runtime_session_id = build_runtime_session_id(user_id, session_id)
-    history = make_history(runtime_session_id)
+    history = amake_history(runtime_session_id)
 
-    # Preserve current runtime history if present.
-    if history.messages:
+    if await history.aget_messages():
         return runtime_session_id
 
-    session_row = _get_session(db, user_id, session_id)
+    session_row = await _get_session(db, user_id, session_id)
     if not session_row:
         return runtime_session_id
 
-    db_messages = (
-        db.query(ChatMessage)
-        .filter(ChatMessage.chat_session_id == session_row.id)
+    stmt = (
+        select(ChatMessage)
+        .where(ChatMessage.chat_session_id == session_row.id)
         .order_by(ChatMessage.id.asc())
-        .all()
     )
+    result = await db.execute(stmt)
+    db_messages = list(result.scalars().all())
     if not db_messages:
         return runtime_session_id
 
@@ -233,10 +235,14 @@ def hydrate_runtime_history_if_empty(
             langchain_messages.append(AIMessage(content=message.content))
 
     if langchain_messages:
-        history.add_messages(langchain_messages)
-        trim_history(history)
+        await history.aadd_messages(langchain_messages)
+        await atrim_history(history)
 
     return runtime_session_id
+
+
+# Backwards-compatible alias retained for any caller still using the legacy name.
+ahydrate_runtime_history_if_empty = hydrate_runtime_history_if_empty
 
 
 def append_turn_to_runtime_history(
@@ -245,7 +251,7 @@ def append_turn_to_runtime_history(
     user_query: str,
     assistant_text: str,
 ) -> None:
-    """Sync variant kept for legacy callers. Prefer
+    """Sync variant kept for legacy callers and existing test patches. Prefer
     `aappend_turn_to_runtime_history` from inside an event loop (DEE-43)."""
     history = make_history(runtime_session_id)
     history.add_messages(
@@ -275,75 +281,39 @@ async def aappend_turn_to_runtime_history(
     await atrim_history(history)
 
 
-async def ahydrate_runtime_history_if_empty(
-    db: Session,
-    *,
-    user_id: str,
-    session_id: str,
-) -> str:
-    """Async variant of `hydrate_runtime_history_if_empty`. Reads chat history
-    from Redis without blocking the event loop; the Postgres backfill
-    queries still hit sync SQLAlchemy and are offloaded to a thread until
-    DEE-45 ships AsyncSession."""
-    runtime_session_id = build_runtime_session_id(user_id, session_id)
-    history = amake_history(runtime_session_id)
-
-    if await history.aget_messages():
-        return runtime_session_id
-
-    def _load_db_messages() -> List[Any]:
-        session_row = _get_session(db, user_id, session_id)
-        if not session_row:
-            return []
-        return list(
-            db.query(ChatMessage)
-            .filter(ChatMessage.chat_session_id == session_row.id)
-            .order_by(ChatMessage.id.asc())
-            .all()
-        )
-
-    db_messages = await asyncio.to_thread(_load_db_messages)
-    if not db_messages:
-        return runtime_session_id
-
-    langchain_messages = []
-    for message in db_messages:
-        if message.role == "user":
-            langchain_messages.append(HumanMessage(content=message.content))
-        elif message.role == "assistant":
-            langchain_messages.append(AIMessage(content=message.content))
-
-    if langchain_messages:
-        await history.aadd_messages(langchain_messages)
-        await atrim_history(history)
-
-    return runtime_session_id
-
-
-def list_sessions(
-    db: Session,
+async def list_sessions(
+    db: AsyncSession,
     *,
     user_id: str,
     limit: int,
     offset: int,
 ) -> Tuple[List[Dict[str, Any]], int]:
-    total = db.query(func.count(ChatSession.id)).filter(ChatSession.user_id == user_id).scalar() or 0
+    total_stmt = (
+        select(func.count(ChatSession.id))
+        .where(ChatSession.user_id == user_id)
+    )
+    total_result = await db.execute(total_stmt)
+    total = total_result.scalar() or 0
 
-    message_count_expr = (
-        db.query(ChatMessage.chat_session_id, func.count(ChatMessage.id).label("message_count"))
+    message_count_subq = (
+        select(
+            ChatMessage.chat_session_id.label("chat_session_id"),
+            func.count(ChatMessage.id).label("message_count"),
+        )
         .group_by(ChatMessage.chat_session_id)
         .subquery()
     )
 
-    rows = (
-        db.query(ChatSession, message_count_expr.c.message_count)
-        .outerjoin(message_count_expr, ChatSession.id == message_count_expr.c.chat_session_id)
-        .filter(ChatSession.user_id == user_id)
+    rows_stmt = (
+        select(ChatSession, message_count_subq.c.message_count)
+        .outerjoin(message_count_subq, ChatSession.id == message_count_subq.c.chat_session_id)
+        .where(ChatSession.user_id == user_id)
         .order_by(ChatSession.last_message_at.desc(), ChatSession.id.desc())
         .offset(offset)
         .limit(limit)
-        .all()
     )
+    rows_result = await db.execute(rows_stmt)
+    rows = rows_result.all()
 
     items: List[Dict[str, Any]] = []
     for session_row, message_count in rows:
@@ -361,33 +331,34 @@ def list_sessions(
     return items, int(total)
 
 
-def get_session_with_messages(
-    db: Session,
+async def get_session_with_messages(
+    db: AsyncSession,
     *,
     user_id: str,
     session_id: str,
     limit: int,
     offset: int,
 ) -> Optional[Dict[str, Any]]:
-    session_row = _get_session(db, user_id, session_id)
+    session_row = await _get_session(db, user_id, session_id)
     if not session_row:
         return None
 
-    total_messages = (
-        db.query(func.count(ChatMessage.id))
-        .filter(ChatMessage.chat_session_id == session_row.id)
-        .scalar()
-        or 0
+    total_stmt = (
+        select(func.count(ChatMessage.id))
+        .where(ChatMessage.chat_session_id == session_row.id)
     )
+    total_result = await db.execute(total_stmt)
+    total_messages = total_result.scalar() or 0
 
-    messages = (
-        db.query(ChatMessage)
-        .filter(ChatMessage.chat_session_id == session_row.id)
+    messages_stmt = (
+        select(ChatMessage)
+        .where(ChatMessage.chat_session_id == session_row.id)
         .order_by(ChatMessage.id.asc())
         .offset(offset)
         .limit(limit)
-        .all()
     )
+    messages_result = await db.execute(messages_stmt)
+    messages = list(messages_result.scalars().all())
 
     return {
         "session_id": session_row.session_id,
@@ -411,13 +382,20 @@ def get_session_with_messages(
 def wrap_streaming_response_for_persistence(
     *,
     response: StreamingResponse,
-    db: Session,
+    db: AsyncSession,
     user_id: str,
     session_id: str,
-    on_assistant_message_saved: Optional[Callable[[str], None]] = None,
+    on_assistant_message_saved: Optional[Callable[[str], Awaitable[None] | None]] = None,
 ) -> StreamingResponse:
     original_iterator = response.body_iterator
     headers = {k: v for k, v in response.headers.items() if k.lower() != "content-length"}
+
+    async def _save_callback(text: str) -> None:
+        if not on_assistant_message_saved:
+            return
+        result = on_assistant_message_saved(text)
+        if hasattr(result, "__await__"):
+            await result
 
     async def wrapped_iterator() -> AsyncIterator[Any]:
         collected_chunks: List[str] = []
@@ -428,26 +406,24 @@ def wrap_streaming_response_for_persistence(
         except Exception:
             partial_answer = extract_answer_text("".join(collected_chunks))
             if partial_answer:
-                persist_assistant_message(
+                await persist_assistant_message(
                     db,
                     user_id=user_id,
                     session_id=session_id,
                     assistant_text=partial_answer,
                 )
-                if on_assistant_message_saved:
-                    on_assistant_message_saved(partial_answer)
+                await _save_callback(partial_answer)
             raise
         else:
             full_answer = extract_answer_text("".join(collected_chunks))
             if full_answer:
-                persist_assistant_message(
+                await persist_assistant_message(
                     db,
                     user_id=user_id,
                     session_id=session_id,
                     assistant_text=full_answer,
                 )
-                if on_assistant_message_saved:
-                    on_assistant_message_saved(full_answer)
+                await _save_callback(full_answer)
 
     return StreamingResponse(
         wrapped_iterator(),

--- a/tests/test_chat_persistence_service.py
+++ b/tests/test_chat_persistence_service.py
@@ -1,21 +1,25 @@
-import asyncio
 import sys
 from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from fastapi.responses import StreamingResponse
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from fastapi.responses import StreamingResponse
-from sqlalchemy import create_engine
-from sqlalchemy import text
-from sqlalchemy.orm import sessionmaker
 
 from services import chat_persistence_service
 
 
-def _make_db_session():
-    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
-    with engine.begin() as conn:
-        conn.execute(
+async def _make_db_session() -> AsyncSession:
+    """Create a fresh in-memory aiosqlite database with chat tables and return
+    an AsyncSession bound to it. Each call gets its own engine so tests are
+    isolated."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+
+    async with engine.begin() as conn:
+        await conn.execute(
             text(
                 """
                 CREATE TABLE chat_sessions (
@@ -31,7 +35,7 @@ def _make_db_session():
                 """
             )
         )
-        conn.execute(
+        await conn.execute(
             text(
                 """
                 CREATE TABLE chat_messages (
@@ -45,7 +49,14 @@ def _make_db_session():
                 """
             )
         )
-    session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+    session_local = async_sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
     return session_local()
 
 
@@ -109,45 +120,49 @@ def test_extract_answer_text_from_agentic_sse_with_error_only_returns_empty():
     assert cleaned == ""
 
 
-def test_persist_and_query_saved_chat():
-    db = _make_db_session()
+@pytest.mark.asyncio
+async def test_persist_and_query_saved_chat():
+    db = await _make_db_session()
 
-    chat_persistence_service.persist_user_message(
-        db,
-        user_id="user-1",
-        session_id="thread-1",
-        user_query="What is tawhid?",
-    )
-    chat_persistence_service.persist_assistant_message(
-        db,
-        user_id="user-1",
-        session_id="thread-1",
-        assistant_text="Tawhid means the oneness of Allah.",
-    )
+    try:
+        await chat_persistence_service.persist_user_message(
+            db,
+            user_id="user-1",
+            session_id="thread-1",
+            user_query="What is tawhid?",
+        )
+        await chat_persistence_service.persist_assistant_message(
+            db,
+            user_id="user-1",
+            session_id="thread-1",
+            assistant_text="Tawhid means the oneness of Allah.",
+        )
 
-    items, total = chat_persistence_service.list_sessions(
-        db,
-        user_id="user-1",
-        limit=20,
-        offset=0,
-    )
-    assert total == 1
-    assert len(items) == 1
-    assert items[0]["session_id"] == "thread-1"
-    assert items[0]["title"] == "What is tawhid?"
-    assert items[0]["message_count"] == 2
+        items, total = await chat_persistence_service.list_sessions(
+            db,
+            user_id="user-1",
+            limit=20,
+            offset=0,
+        )
+        assert total == 1
+        assert len(items) == 1
+        assert items[0]["session_id"] == "thread-1"
+        assert items[0]["title"] == "What is tawhid?"
+        assert items[0]["message_count"] == 2
 
-    detail = chat_persistence_service.get_session_with_messages(
-        db,
-        user_id="user-1",
-        session_id="thread-1",
-        limit=100,
-        offset=0,
-    )
-    assert detail is not None
-    assert detail["session_id"] == "thread-1"
-    assert detail["total_messages"] == 2
-    assert [message["role"] for message in detail["messages"]] == ["user", "assistant"]
+        detail = await chat_persistence_service.get_session_with_messages(
+            db,
+            user_id="user-1",
+            session_id="thread-1",
+            limit=100,
+            offset=0,
+        )
+        assert detail is not None
+        assert detail["session_id"] == "thread-1"
+        assert detail["total_messages"] == 2
+        assert [message["role"] for message in detail["messages"]] == ["user", "assistant"]
+    finally:
+        await db.close()
 
 
 async def _collect_streaming_response(response: StreamingResponse) -> str:
@@ -159,83 +174,90 @@ async def _collect_streaming_response(response: StreamingResponse) -> str:
     return "".join(chunks)
 
 
-def test_wrap_streaming_response_for_persistence_saves_only_agentic_answer_text():
-    db = _make_db_session()
-    chat_persistence_service.persist_user_message(
-        db,
-        user_id="user-1",
-        session_id="thread-2",
-        user_query="Tell me about patience",
-    )
-
-    async def body():
-        yield 'event: status\ndata: {"step":"agent","message":"Agent thinking..."}\n\n'
-        yield 'event: response_chunk\ndata: {"token":"Patience"}\n\n'
-        yield 'event: response_chunk\ndata: {"token":" is beautiful."}\n\n'
-        yield 'event: response_end\ndata: {}\n\n'
-        yield 'event: done\ndata: {}\n\n'
-
-    callback_values = []
-    response = StreamingResponse(body(), media_type="text/event-stream")
-    wrapped = chat_persistence_service.wrap_streaming_response_for_persistence(
-        response=response,
-        db=db,
-        user_id="user-1",
-        session_id="thread-2",
-        on_assistant_message_saved=callback_values.append,
-    )
-
-    streamed = asyncio.run(_collect_streaming_response(wrapped))
-    assert 'event: response_chunk' in streamed
-
-    detail = chat_persistence_service.get_session_with_messages(
-        db,
-        user_id="user-1",
-        session_id="thread-2",
-        limit=100,
-        offset=0,
-    )
-    assert detail is not None
-    assert detail["messages"][-1]["role"] == "assistant"
-    assert detail["messages"][-1]["content"] == "Patience is beautiful."
-    assert callback_values == ["Patience is beautiful."]
-
-
-def test_wrap_streaming_response_for_persistence_saves_partial_agentic_answer_on_error():
-    db = _make_db_session()
-    chat_persistence_service.persist_user_message(
-        db,
-        user_id="user-1",
-        session_id="thread-3",
-        user_query="Tell me about patience",
-    )
-
-    async def body():
-        yield 'event: status\ndata: {"step":"agent","message":"Agent thinking..."}\n\n'
-        yield 'event: response_chunk\ndata: {"token":"Partial"}\n\n'
-        yield 'event: response_chunk\ndata: {"token":" answer"}\n\n'
-        raise RuntimeError("stream interrupted")
-
-    response = StreamingResponse(body(), media_type="text/event-stream")
-    wrapped = chat_persistence_service.wrap_streaming_response_for_persistence(
-        response=response,
-        db=db,
-        user_id="user-1",
-        session_id="thread-3",
-    )
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_for_persistence_saves_only_agentic_answer_text():
+    db = await _make_db_session()
 
     try:
-        asyncio.run(_collect_streaming_response(wrapped))
-        assert False, "Expected stream interruption"
-    except RuntimeError as exc:
-        assert str(exc) == "stream interrupted"
+        await chat_persistence_service.persist_user_message(
+            db,
+            user_id="user-1",
+            session_id="thread-2",
+            user_query="Tell me about patience",
+        )
 
-    detail = chat_persistence_service.get_session_with_messages(
-        db,
-        user_id="user-1",
-        session_id="thread-3",
-        limit=100,
-        offset=0,
-    )
-    assert detail is not None
-    assert detail["messages"][-1]["content"] == "Partial answer"
+        async def body() -> AsyncIterator[str]:
+            yield 'event: status\ndata: {"step":"agent","message":"Agent thinking..."}\n\n'
+            yield 'event: response_chunk\ndata: {"token":"Patience"}\n\n'
+            yield 'event: response_chunk\ndata: {"token":" is beautiful."}\n\n'
+            yield 'event: response_end\ndata: {}\n\n'
+            yield 'event: done\ndata: {}\n\n'
+
+        callback_values = []
+        response = StreamingResponse(body(), media_type="text/event-stream")
+        wrapped = chat_persistence_service.wrap_streaming_response_for_persistence(
+            response=response,
+            db=db,
+            user_id="user-1",
+            session_id="thread-2",
+            on_assistant_message_saved=callback_values.append,
+        )
+
+        streamed = await _collect_streaming_response(wrapped)
+        assert 'event: response_chunk' in streamed
+
+        detail = await chat_persistence_service.get_session_with_messages(
+            db,
+            user_id="user-1",
+            session_id="thread-2",
+            limit=100,
+            offset=0,
+        )
+        assert detail is not None
+        assert detail["messages"][-1]["role"] == "assistant"
+        assert detail["messages"][-1]["content"] == "Patience is beautiful."
+        assert callback_values == ["Patience is beautiful."]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_for_persistence_saves_partial_agentic_answer_on_error():
+    db = await _make_db_session()
+
+    try:
+        await chat_persistence_service.persist_user_message(
+            db,
+            user_id="user-1",
+            session_id="thread-3",
+            user_query="Tell me about patience",
+        )
+
+        async def body() -> AsyncIterator[str]:
+            yield 'event: status\ndata: {"step":"agent","message":"Agent thinking..."}\n\n'
+            yield 'event: response_chunk\ndata: {"token":"Partial"}\n\n'
+            yield 'event: response_chunk\ndata: {"token":" answer"}\n\n'
+            raise RuntimeError("stream interrupted")
+
+        response = StreamingResponse(body(), media_type="text/event-stream")
+        wrapped = chat_persistence_service.wrap_streaming_response_for_persistence(
+            response=response,
+            db=db,
+            user_id="user-1",
+            session_id="thread-3",
+        )
+
+        with pytest.raises(RuntimeError, match="stream interrupted"):
+            await _collect_streaming_response(wrapped)
+
+        detail = await chat_persistence_service.get_session_with_messages(
+            db,
+            user_id="user-1",
+            session_id="thread-3",
+            limit=100,
+            offset=0,
+        )
+        assert detail is not None
+        assert detail["messages"][-1]["content"] == "Partial answer"
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary

Phase 6 of [DEE-36](https://linear.app/deen-team/issue/DEE-36) async migration. Closes [DEE-45](https://linear.app/deen-team/issue/DEE-45).

- Cuts `services/chat_persistence_service.py` off the sync psycopg2 engine and onto an asyncpg-backed `AsyncSession`. All 8 DB functions converted to SQLAlchemy 2.0 `select(...)` style.
- Adds `db/async_session.py` (asyncpg engine + `AsyncSessionLocal` + `get_db_async()` dependency). URL is built from the same `db/config.py` settings as the sync engine, so both engines always target the same Supabase DB.
- The chat router (`api/chat.py`) migrates atomically: 4 DB-using endpoints switched to `Depends(get_db_async)` with `await` at every call site. Other 3 endpoints (no DB) unchanged.
- Drops the `asyncio.to_thread` wrapper from `ahydrate_runtime_history_if_empty` (Phase 4 stop-gap).
- Includes `docs(DEE-36)` commit syncing `CLAUDE.md` with everything that landed in DEE-40 through DEE-44.

## Impacted endpoints

`POST /chat/stream`, `POST /chat/stream/agentic`, `GET /chat/saved`, `GET /chat/saved/{session_id}` — all switch from sync `Session` to `AsyncSession`. SSE contract unchanged. The 3 endpoints that don't use DB (`POST /chat/`, `POST /chat/agentic`, `DELETE /chat/session/{session_id}`) are unchanged.

## Out of scope (deliberate)

- Other routers (account, memory_admin, hikmah, onboarding, primers) keep `Depends(get_db)` — per [DEE-45](https://linear.app/deen-team/issue/DEE-45) plan, each migrates atomically in its own follow-up sub-issue.
- Alembic migrations stay sync (recommended in DEE-45 plan).

## Migration / env var changes

- No Alembic migrations.
- `requirements.txt`: `+aiosqlite==0.20.0` (test-only — async sqlite for the in-memory tests; no production dependency).
- No new env vars. The async engine reuses `DB_USER` / `DB_PASSWORD` / `DB_HOST` / `DB_PORT` / `DB_NAME` from `.env` via `db/config.py`.
- Async engine uses `connect_args={"ssl": "require"}` to mirror the sync engine's `sslmode=require` — encrypt-but-don't-verify, required for Supabase on Windows where the CA chain isn't in the local trust store.

## Test plan

- [x] `pytest tests/test_chat_persistence_service.py` — 8/8 pass on aiosqlite (rewritten using `async_sessionmaker` + `@pytest.mark.asyncio`; all prior assertions preserved).
- [x] `pytest tests --ignore=tests/db -q` — 210 pass / 13 fail. Exact parity with `main` baseline; the 13 reds are pre-existing fixtures from DEE-41/42/44 unrelated to this change.
- [x] End-to-end smoke against real Supabase — two-turn `/chat/stream/agentic` with the same `session_id`. Turn 2 references turn 1 context, proving async DB write → async DB read → Redis hydration end-to-end.
- [ ] Reviewer to spot-check `/chat/saved` and `/chat/saved/{session_id}` against a session created via `/chat/stream/agentic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)