### PR TITLE
ci(DEE-47): add deploy-dev workflow for main -> dev Hetzner pipeline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,109 @@
+name: Deploy main → dev (Hetzner)
+
+# DEE-47 Phase 1: manual deployment of any git ref to the dev Hetzner box.
+# Trigger is workflow_dispatch only (cost + safety per DEE-47 plan); push
+# triggers can be added later as a Phase 3 follow-up. Runs on the
+# self-hosted runner registered under the `dev-deploy` label.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (default: main)"
+        required: false
+        default: main
+      no_cache:
+        description: "Force docker build --no-cache"
+        required: false
+        type: boolean
+        default: false
+
+# Serialise dev deploys; never queue more than one. cancel-in-progress=false
+# so a deploy that's already restarting the container isn't yanked
+# mid-restart by an accidental second click.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, dev-deploy]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - name: Write .env from GH Secrets
+        # umask 077 ensures the .env is created with mode 600 (owner-only
+        # read/write). Subsequent docker compose up bind-mounts it into the
+        # container via env_file in docker-compose.yml — no secret values
+        # appear in logs because every ${{ secrets.* }} is auto-redacted by
+        # GitHub Actions.
+        run: |
+          umask 077
+          cat > .env <<EOF
+          ENV=${{ secrets.ENV }}
+          ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+          LARGE_LLM=${{ secrets.LARGE_LLM }}
+          SMALL_LLM=${{ secrets.SMALL_LLM }}
+          PINECONE_API_KEY=${{ secrets.PINECONE_API_KEY }}
+          DEEN_DENSE_INDEX_NAME=${{ secrets.DEEN_DENSE_INDEX_NAME }}
+          DEEN_SPARSE_INDEX_NAME=${{ secrets.DEEN_SPARSE_INDEX_NAME }}
+          QURAN_DENSE_INDEX_NAME=${{ secrets.QURAN_DENSE_INDEX_NAME }}
+          DEEN_FIQH_DENSE_INDEX_NAME=${{ secrets.DEEN_FIQH_DENSE_INDEX_NAME }}
+          DEEN_FIQH_SPARSE_INDEX_NAME=${{ secrets.DEEN_FIQH_SPARSE_INDEX_NAME }}
+          REDIS_URL=${{ secrets.REDIS_URL }}
+          REDIS_KEY_PREFIX=${{ secrets.REDIS_KEY_PREFIX }}
+          REDIS_TTL_SECONDS=${{ secrets.REDIS_TTL_SECONDS }}
+          REDIS_MAX_MESSAGES=${{ secrets.REDIS_MAX_MESSAGES }}
+          DATABASE_URL=${{ secrets.DATABASE_URL }}
+          ASYNC_DATABASE_URL=${{ secrets.ASYNC_DATABASE_URL }}
+          DB_HOST=${{ secrets.DB_HOST }}
+          DB_PORT=${{ secrets.DB_PORT }}
+          DB_NAME=${{ secrets.DB_NAME }}
+          DB_USER=${{ secrets.DB_USER }}
+          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          SENTRY_ENABLED=${{ secrets.SENTRY_ENABLED }}
+          CORS_ALLOW_ORIGINS=${{ secrets.CORS_ALLOW_ORIGINS }}
+          EOF
+
+      - name: Build image
+        run: |
+          if [ "${{ inputs.no_cache }}" = "true" ]; then
+            docker compose build --no-cache
+          else
+            docker compose build
+          fi
+
+      - name: Restart service
+        run: |
+          docker compose down
+          docker compose up -d
+
+      - name: Wait for /health (60s budget)
+        # Polls the in-container health endpoint via the host's loopback
+        # because docker-compose.yml maps :8000 (Caddy fronts HTTPS but is
+        # in a separate container). 30 attempts × 2s = 60s budget covers
+        # cold-start of the sentence-transformers model.
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "✓ Health OK after ${i}×2s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "✗ Health check timed out"
+          docker logs --tail=200 deen-backend
+          exit 1
+
+      - name: Print container status
+        if: always()
+        run: docker ps --filter name=deen-backend


### PR DESCRIPTION
Phase 1 of DEE-47. Adds a manually-triggered GitHub Actions workflow that deploys any git ref to the dev Hetzner box via a self-hosted runner. Trigger is workflow_dispatch only — no push triggers (cost + safety per the approved DEE-47 plan).

Workflow shape:
* `runs-on: [self-hosted, dev-deploy]` — targets the dev Hetzner box by label so prod deploys can't accidentally route here later.
* Inputs: `ref` (default main) and `no_cache` (force docker --no-cache).
* `concurrency: deploy-dev` with `cancel-in-progress: false` — serialises dev deploys; never yanks an in-progress restart.
* Writes .env from GH Secrets under `umask 077` so the file is mode 600, owner-only. Every secret is auto-redacted in workflow logs by GitHub's `${{ secrets.* }}` substitution.
* Build -> down -> up -d -> poll /health 30x2s (60s budget covering sentence-transformers cold start) -> dump container logs on failure -> always print container status.

Out of scope (Phase 3 follow-ups, parked):
* Alembic migrations as part of deploy
* Auto-rollback on /health failure
* Push trigger on main (revisit cost when needed)
* Slack/Discord failure notifications

Required before this workflow can run:
1. Dev Hetzner box provisioned with Docker, non-root `deploy` user, DNS subdomain pointing at it (manual, per Phase 1.1 of plan)
2. Initial manual `docker compose up` baseline on the dev box (Phase 1.2)
3. GH Actions self-hosted runner registered with labels `[self-hosted, linux, dev-deploy]` (Phase 1.3)
4. Repo Secrets added — one per env var in core/config.py (Phase 1.4)

These manual setup steps are documented in the DEE-47 Linear ticket.

Verification plan (after manual steps complete):
* Dispatch workflow against `main` -> green within ~5min
* `curl https://api-dev.thedeenfoundation.com/health` -> 200
* Two-turn /chat/stream/agentic against the dev URL — async chain works end-to-end
* Re-dispatch with no changes -> green (idempotent)
* Re-dispatch with `no_cache: true` -> green (~5-8min)
* Dispatch a feature branch with a syntax error -> workflow fails at build, previous container keeps serving traffic