### PR TITLE
Fix Supabase pooler exhaustion (DEE-59) + add Linear MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## MCP servers
+
+Project-scoped MCP servers are declared in `.mcp.json` at the repo root (committed, so they
+carry over to both local CLI and Claude Code on the web).
+
+- **linear** — Linear's hosted MCP server (`https://mcp.linear.app/mcp`, streamable HTTP, OAuth 2.1).
+  Issues are tracked in Linear (`DEE-*` tickets). After cloning, run `/mcp` once and complete the
+  browser OAuth flow to authenticate; tools then cover finding/creating/updating Linear issues,
+  projects, and comments.
+
 ## Commands
 
 ```bash

--- a/db/async_session.py
+++ b/db/async_session.py
@@ -22,6 +22,14 @@ async_engine = create_async_engine(
     future=True,
     pool_pre_ping=True,
     echo=False,
+    # Bounded pool — see db/session.py for the full connection-budget math.
+    # Per worker: this async engine (2+1=3) + the sync engine (2+1=3) = 6;
+    # Dockerfile `-w 2` -> 12 < 15 (Supabase session-mode client cap).
+    # Recompute if the worker count changes.
+    pool_size=2,
+    max_overflow=1,
+    pool_recycle=300,
+    pool_timeout=30,
     # asyncpg's `ssl="require"` mirrors psycopg2's `sslmode=require` used by the
     # sync engine in db/session.py — encrypt but skip cert chain verification.
     # Supabase's CA isn't in the local Python trust store on Windows, so `ssl=True`

--- a/db/session.py
+++ b/db/session.py
@@ -3,11 +3,28 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 from .config import settings
 
 # Set echo to False to avoid SQL statement noise in logs
+# Connection budget for the Supabase pooler in SESSION mode (port 5432), which
+# caps total client connections at 15 (every open pooled connection holds a slot,
+# even when idle).
+#
+# Per gunicorn worker:
+#   sync engine  (here):                pool_size 2 + max_overflow 1 = 3
+#   async engine (db/async_session.py): pool_size 2 + max_overflow 1 = 3
+#   -> 6 connections per worker
+# Dockerfile runs `-w 2`  ->  6 x 2 = 12 < 15.  (Headroom = 3.)
+#
+# IMPORTANT: if the Dockerfile worker count changes, recompute this budget.
+# pool_recycle=300 drops idle connections before the pooler reaps them;
+# pool_timeout=30 fails fast instead of hanging when the pool is saturated.
 engine = create_engine(
     settings.DATABASE_URL,
     future=True,
     pool_pre_ping=True,
     echo=False,
+    pool_size=2,
+    max_overflow=1,
+    pool_recycle=300,
+    pool_timeout=30,
     connect_args={"sslmode": "require"},
 )
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/services/hikmah_quiz_service.py
+++ b/services/hikmah_quiz_service.py
@@ -296,18 +296,34 @@ class HikmahQuizService:
         lesson = self.db.get(Lesson, page.lesson_id) if page.lesson_id else None
         topics_tested = question.tags or (lesson.tags if lesson and lesson.tags else [])
 
+        # Snapshot everything the memory event needs as plain values BEFORE
+        # releasing the DB connection. The LLM memory analysis can take several
+        # seconds, and we must not hold a pooled connection during it (Supabase
+        # session mode caps clients at 15). See _trigger_incorrect_quiz_memory_event.
+        memory_payload = {
+            "user_id": user_id,
+            "lesson_content_id": lesson_content_id,
+            "lesson_id": page.lesson_id,
+            "topics_tested": topics_tested,
+            "question_id": int(question.id),
+            "question_prompt": question.prompt,
+            "selected_choice_id": int(selected_choice.id),
+            "selected_choice_key": selected_choice.choice_key,
+            "selected_choice_text": selected_choice.choice_text,
+            "correct_choice_id": int(correct_choice.id),
+            "correct_choice_key": correct_choice.choice_key,
+            "correct_choice_text": correct_choice.choice_text,
+        }
+
+        # Release this session's connection back to the pool before the long LLM
+        # call. The reads above (e.g. self.db.get(Lesson, ...)) opened a new
+        # read-only transaction; rollback ends it and frees the connection.
+        # (Use rollback, not close — process_quiz_submission_background owns the
+        # close in its finally block.)
+        self.db.rollback()
+
         try:
-            asyncio.run(
-                self._trigger_incorrect_quiz_memory_event(
-                    user_id=user_id,
-                    lesson_content_id=lesson_content_id,
-                    question=question,
-                    selected_choice=selected_choice,
-                    correct_choice=correct_choice,
-                    lesson_id=page.lesson_id,
-                    topics_tested=topics_tested,
-                )
-            )
+            asyncio.run(self._trigger_incorrect_quiz_memory_event(**memory_payload))
         except Exception:
             logger.exception(
                 "Failed to process incorrect quiz memory event",
@@ -323,17 +339,20 @@ class HikmahQuizService:
         self,
         user_id: str,
         lesson_content_id: int,
-        question: LessonPageQuizQuestion,
-        selected_choice: LessonPageQuizChoice,
-        correct_choice: LessonPageQuizChoice,
         lesson_id: Optional[int],
         topics_tested: List[str],
+        question_id: int,
+        question_prompt: str,
+        selected_choice_id: int,
+        selected_choice_key: str,
+        selected_choice_text: str,
+        correct_choice_id: int,
+        correct_choice_key: str,
+        correct_choice_text: str,
     ) -> None:
         from agents.core.universal_memory_agent import UniversalMemoryAgent, InteractionType
 
-        memory_agent = UniversalMemoryAgent(self.db)
-
-        quiz_id = f"page:{lesson_content_id}:question:{question.id}"
+        quiz_id = f"page:{lesson_content_id}:question:{question_id}"
         interaction_data = {
             "quiz_id": quiz_id,
             "lesson_id": str(lesson_id) if lesson_id is not None else None,
@@ -344,17 +363,17 @@ class HikmahQuizService:
             "incorrect_topics": topics_tested,
             "question_details": [
                 {
-                    "question_id": int(question.id),
-                    "prompt": question.prompt,
+                    "question_id": question_id,
+                    "prompt": question_prompt,
                     "selected_choice": {
-                        "id": int(selected_choice.id),
-                        "key": selected_choice.choice_key,
-                        "text": selected_choice.choice_text,
+                        "id": selected_choice_id,
+                        "key": selected_choice_key,
+                        "text": selected_choice_text,
                     },
                     "correct_choice": {
-                        "id": int(correct_choice.id),
-                        "key": correct_choice.choice_key,
-                        "text": correct_choice.choice_text,
+                        "id": correct_choice_id,
+                        "key": correct_choice_key,
+                        "text": correct_choice_text,
                     },
                 }
             ],
@@ -363,17 +382,25 @@ class HikmahQuizService:
         context = {
             "source": "hikmah_page_quiz",
             "lesson_content_id": int(lesson_content_id),
-            "question_prompt": question.prompt,
-            "selected_choice_text": selected_choice.choice_text,
-            "correct_choice_text": correct_choice.choice_text,
+            "question_prompt": question_prompt,
+            "selected_choice_text": selected_choice_text,
+            "correct_choice_text": correct_choice_text,
         }
 
-        await memory_agent.analyze_interaction(
-            user_id=user_id,
-            interaction_type=InteractionType.QUIZ_RESULT,
-            interaction_data=interaction_data,
-            context=context,
-        )
+        # Run the LLM memory analysis on its OWN short-lived session so the long
+        # inference never holds the quiz path's pooled connection. Mirrors the
+        # pattern in modules/generation/stream_generator.py::_update_hikmah_memory.
+        memory_db = SessionLocal()
+        try:
+            memory_agent = UniversalMemoryAgent(memory_db)
+            await memory_agent.analyze_interaction(
+                user_id=user_id,
+                interaction_type=InteractionType.QUIZ_RESULT,
+                interaction_data=interaction_data,
+                context=context,
+            )
+        finally:
+            memory_db.close()
 
     # ------------------
     # Internal utilities


### PR DESCRIPTION
## Purpose

This branch carries **two independent changes** (both committed here per the working-branch convention):

1. **Fix Supabase pooler exhaustion** — the production bug (`DEE-59`).
2. **Add the Linear MCP server config** — project-scoped `.mcp.json` + docs.

---

## 1. Fix: Supabase pooler exhaustion (DEE-59)

**Symptom:** `(psycopg2.OperationalError) ... FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15`, surfacing on various API calls (first noticed in the hikmah tree flow).

**Root cause:** The Supabase pooler runs in **session mode** (port 5432), capping total client connections at **15** (every open pooled connection holds a slot, even when idle). Both SQLAlchemy engines used the default pool (`pool_size=5` + `max_overflow=10` = 15 each), and `Dockerfile` runs gunicorn `-w 2` — worst case ~60 connections demanded vs a 15 cap. Aggravated by the hikmah quiz background path holding a pooled connection across multi-second LLM memory analysis.

**Changes:**
- `db/session.py`, `db/async_session.py` — bound both engines: `pool_size=2, max_overflow=1, pool_recycle=300, pool_timeout=30`. Budget: per worker 3+3=6 × `-w 2` = **12 < 15** (documented in a comment, with the worker-count assumption called out).
- `services/hikmah_quiz_service.py` — on the incorrect-answer path, snapshot the memory payload as primitives, `rollback()` to release `self.db` **before** the LLM call, then run `UniversalMemoryAgent` on its own short-lived `SessionLocal()` (mirrors the existing safe pattern in `modules/generation/stream_generator.py::_update_hikmah_memory`). Quiz attempt + memory event behavior unchanged.

**Impacted endpoints:** all DB-backed routes benefit (global connection budget). Directly touched path: hikmah page quiz submission (`POST /.../quiz-submit` background processing).

**Migrations:** none. **Env vars:** none changed.

**Test evidence:**
- Edited module imports cleanly without the ML stack; isolated re-run of the existing incorrect-answer test logic gives `add=1, commit=1, asyncio.run=1` (behavior preserved) plus the new `rollback=1` (connection released early). The committed pytest test (`tests/test_hikmah_quiz_service.py`) only asserts add/commit/run counts, so it stays green — **no test changes required**.
- Both engines construct with the new args: `QueuePool` / `AsyncAdaptedQueuePool`, `size=2, overflow=1, recycle=300, timeout=30`.
- Note: the full `pytest tests -q` suite was **not** run in the ephemeral web container (importing `services/__init__.py` instantiates a HuggingFace model + torch). Please let CI run the full suite before merge.

**Follow-up (separate issue, not in this PR):** evaluate migrating to the Supabase transaction-mode pooler (port 6543) for higher concurrency — requires asyncpg `statement_cache_size=0` (+ likely `NullPool`).

---

## 2. Chore: add Linear MCP server config

- `.mcp.json` (new, repo root) — declares Linear's hosted MCP server (`https://mcp.linear.app/mcp`, streamable HTTP, OAuth 2.1). Project-scoped so it carries over to both local CLI and Claude Code on the web. No secrets committed (OAuth handled via `/mcp`).
- `CLAUDE.md` — documents the server and the one-time `/mcp` OAuth auth step.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Kvp9aACbiMi6fVdHT5PUCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kvp9aACbiMi6fVdHT5PUCY)_