### PR TITLE
feat: warmer chatbot personality + dynamic refusals + casual-message handling (DEE-12)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-05-04 after v1.4 milestone archived)
 Milestone v1.4 complete — all 3 phases, 9 plans shipped.
 Next: `/gsd-new-milestone` to define v1.5 requirements and roadmap.
 Status: v1.4 milestone complete — OBS-02 human action required after next deploy
-Last activity: 2026-06-29 — Completed quick task 260629-ia2: Fix DEE-55 Ask Deen over-refusal on short meaningful selected text
+Last activity: 2026-07-01 — Completed quick task 260701-j8v: Improve chatbot personality (DEE-12) — warmer voice, dynamic non-Islamic refusal, casual-message handling
 
 Progress bar: `▓▓▓▓▓▓░░░░` 67% (2/3 phases complete)
 
@@ -93,6 +93,7 @@ None.
 | 260510-qcx | Fix primer stream CancelledError handling — stop Sentry from capturing benign SSE client disconnects | 2026-05-10 | 8f03c25 | Complete | [260510-qcx-fix-primer-stream-cancellederror-handlin](./quick/260510-qcx-fix-primer-stream-cancellederror-handlin/) |
 | 260530-ddo | Skip quiz pages in hikmah upsert, attach MCQs to last text page, fix meta.total_pages count | 2026-05-30 | 64e3635 | Complete | [260530-ddo-skip-quiz-pages-in-hikmah-upsert-attach-](./quick/260530-ddo-skip-quiz-pages-in-hikmah-upsert-attach-/) |
 | 260629-ia2 | Fix DEE-55 Ask Deen over-refusal on short meaningful selected text | 2026-06-29 | 14b6480 | Complete | [260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor](./quick/260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor/) |
+| 260701-j8v | Improve chatbot personality: warmer voice, dynamic non-Islamic refusal, casual-message handling (DEE-12) | 2026-07-01 | 3c376a5 | Verified | [260701-j8v-improve-chatbot-personality-warmer-answe](./quick/260701-j8v-improve-chatbot-personality-warmer-answe/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-PLAN.md
+++ b/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-PLAN.md
@@ -1,0 +1,529 @@
+---
+phase: 260701-j8v
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - core/prompt_templates.py
+  - modules/classification/classifier.py
+  - agents/tools/classification_tools.py
+  - agents/state/chat_state.py
+  - agents/core/chat_agent.py
+  - agents/prompts/agent_prompts.py
+  - tests/test_dee12_personality.py
+autonomous: true
+requirements:
+  - DEE-12
+must_haves:
+  truths:
+    - "Answers from the main chat path feel warmer and more encouraging without losing scholarly authority"
+    - "A non-Islamic query (e.g., 'who won the World Cup?') receives a personalized, LLM-generated decline that varies per query rather than a fixed string"
+    - "A casual/social message (e.g., 'hi', 'salam', 'thank you!') receives a brief warm welcome reply instead of a retrieval-failure error"
+    - "Casual messages do not trigger document retrieval — they short-circuit to early exit"
+    - "Islamic questions still work normally — retrieval and grounded answers unaffected"
+    - "LLM failure on dynamic refusals falls back to a hardcoded constant (no user-facing error)"
+    - "aclassify_non_islamic_query and classify_non_islamic_query remain bool-returning and untouched (legacy core/pipeline.py callers unaffected)"
+  artifacts:
+    - path: "core/prompt_templates.py"
+      provides: "intentClassifierSystemTemplate + intent_classifier_messages() + warmed generatorSystemTemplate"
+    - path: "modules/classification/classifier.py"
+      provides: "aclassify_intent() returning 'islamic'|'non_islamic'|'casual'"
+    - path: "agents/tools/classification_tools.py"
+      provides: "check_if_non_islamic_tool returning is_non_islamic + is_casual"
+    - path: "agents/state/chat_state.py"
+      provides: "is_casual: Optional[bool] field + default in create_initial_state"
+    - path: "agents/core/chat_agent.py"
+      provides: "_check_early_exit_node with LLM-generated non-Islamic + casual branches; _should_continue routing is_casual to exit; _tool_node setting is_casual from tool result"
+    - path: "agents/prompts/agent_prompts.py"
+      provides: "EARLY_EXIT_CASUAL constant alongside EARLY_EXIT_NON_ISLAMIC"
+    - path: "tests/test_dee12_personality.py"
+      provides: "Deterministic unit + opt-in real_llm tests for all three DEE-12 behaviours"
+  key_links:
+    - from: "agents/tools/classification_tools.py::check_if_non_islamic_tool"
+      to: "modules/classification/classifier.py::aclassify_intent"
+      via: "direct call replacing aclassify_non_islamic_query call"
+    - from: "agents/core/chat_agent.py::_tool_node"
+      to: "agents/state/chat_state.py::is_casual"
+      via: "result_data.get('is_casual', False) on check_if_non_islamic_tool branch"
+    - from: "agents/core/chat_agent.py::_should_continue"
+      to: "check_early_exit node"
+      via: "or state.get('is_casual') added to early-exit routing condition"
+    - from: "agents/core/chat_agent.py::_check_early_exit_node"
+      to: "core.chat_models.get_classifier_model + _retry_ainvoke"
+      via: "UNETHICAL pattern reused for casual and non_islamic dynamic refusals"
+---
+
+<objective>
+Implement DEE-12: three coordinated improvements to chatbot personality and intent routing.
+
+Purpose: The chatbot currently sounds robotic on answers, returns a fixed non-Islamic refusal string (no personalization), and crashes into a retrieval-failure error on casual messages (greetings, thanks). This change makes every interaction feel warmer and routes casual social messages to a graceful, inviting reply.
+
+Output:
+- Warmer generatorSystemTemplate (tone directive added, all rules preserved)
+- 3-label intent classifier (islamic / non_islamic / casual) replacing the boolean non-Islamic check on the agentic path only
+- Casual routing: is_casual flag propagated through state and _should_continue; _check_early_exit_node generates warm LLM reply
+- Dynamic non-Islamic refusal matching the existing UNETHICAL pattern
+- Full test coverage (deterministic mocked unit tests + opt-in real_llm)
+</objective>
+
+<execution_context>
+@/Users/admin2/.claude/plugins/cache/gsd-plugin/gsd/4.0.2/workflows/execute-plan.md
+@/Users/admin2/.claude/plugins/cache/gsd-plugin/gsd/4.0.2/templates/summary.md
+</execution_context>
+
+<context>
+@/Users/admin2/deen-backend/.planning/STATE.md
+@/Users/admin2/deen-backend/CLAUDE.md
+
+<!-- Key interfaces the executor needs — extracted from codebase. Use directly, no exploration. -->
+<interfaces>
+From core/prompt_templates.py:
+- make_cached_system_message imported from core.chat_models
+- fiqhClassifierSystemTemplate / fiqhClassifierUserTemplate: structural template for intent classifier
+- nonIslamicClassifierSystemTemplate / nonIslamicClassiferUserTemplate: non_islamic examples to reuse
+- generatorSystemTemplate (lines 8-58): plain string, no cache, formatted at runtime via .format()
+- generator_messages() builds [SystemMessage(...), *history, HumanMessage(...)]; system NOT cached (D-05)
+
+From modules/classification/classifier.py:
+- aclassify_non_islamic_query(query, session_id) -> bool  [KEEP UNTOUCHED]
+- classify_non_islamic_query(query, session_id) -> bool   [KEEP UNTOUCHED]
+- Pattern for new async function: use @anthropic_retry on the raw _call helper, wrap in async outer
+- context.get_recent_context(session_id) for chatContext
+
+From agents/core/chat_agent.py:
+- _retry_ainvoke(model, messages) — the retry helper used by all node LLM calls
+- UNETHICAL branch (lines 326-346): exact pattern to copy for dynamic refusals
+  - from core.chat_models import get_classifier_model
+  - model = get_classifier_model()
+  - response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+  - msg = response.content.strip()
+  - except block: logger.error(...) + hardcoded fallback constant
+- _tool_node check_if_non_islamic_tool branch (line 249-252): add is_casual alongside is_non_islamic
+- _should_continue (line 456): add `or state.get("is_casual")` to the early-exit condition
+
+From agents/state/chat_state.py:
+- is_non_islamic: Optional[bool] = None  [mirror this for is_casual]
+- create_initial_state returns ChatState(..., is_casual=None, ...)
+
+From agents/prompts/agent_prompts.py:
+- EARLY_EXIT_NON_ISLAMIC = "..." (line 136) — fallback constant, keep unchanged
+- Add EARLY_EXIT_CASUAL = "..." next to it as fallback for the casual branch
+
+From agents/tools/classification_tools.py:
+- check_if_non_islamic_tool calls classifier.aclassify_non_islamic_query(query, session_id)
+- Change to: label = await classifier.aclassify_intent(query, session_id)
+- Derive: is_non_islamic = (label == "non_islamic"), is_casual = (label == "casual")
+- Return both keys; except fallback returns is_non_islamic=False, is_casual=False
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Intent classifier + warmer tone prompt</name>
+  <files>
+    core/prompt_templates.py,
+    modules/classification/classifier.py,
+    agents/prompts/agent_prompts.py
+  </files>
+  <behavior>
+    - intent_classifier_messages("hi", "") -> list with cached system message containing "casual" class
+    - intent_classifier_messages("who won the World Cup?", "") -> list with system message containing "non_islamic" examples
+    - aclassify_intent("hi", None) -> "casual" when LLM returns "casual"
+    - aclassify_intent("who won the World Cup?", None) -> "non_islamic" when LLM returns "non_islamic"
+    - aclassify_intent("what is Imamate?", None) -> "islamic" when LLM returns "islamic"
+    - EARLY_EXIT_CASUAL is importable from agents.prompts.agent_prompts
+  </behavior>
+  <action>
+**core/prompt_templates.py** — two additions:
+
+1. Add `intentClassifierSystemTemplate` after `nonIslamicClassifierSystemTemplate`. Structure mirrors `fiqhClassifierSystemTemplate`. The template must:
+   - Instruct the model to respond with exactly one lowercase token: `islamic`, `non_islamic`, or `casual`
+   - Define `casual` as: greetings ("hi", "hello", "salam", "as-salamu alaykum"), thanks ("thank you", "jazakallah", "shukran"), small talk ("how are you", "good morning"), any purely social opener with no Islamic question
+   - Define `non_islamic` using the same examples as `nonIslamicClassifierSystemTemplate` (celebrities, weather, math, crypto, etc.)
+   - Define `islamic` as any query about theology, history, Quran, hadith, Shia beliefs, jurisprudence, Imams, etc.
+   - Include at least 5 labelled examples per class. Casual examples: "hi → casual", "salam! → casual", "thank you so much → casual", "good morning → casual", "how are you doing? → casual". Non-Islamic: reuse the 5 from nonIslamicClassifierSystemTemplate. Islamic: reuse 3-4 from fiqhClassifierSystemTemplate non-fiqh examples.
+   - End with: "Only respond with one of: islamic, non_islamic, casual. No explanation."
+
+2. Add `intent_classifier_messages(query: str, chatContext: str) -> list` function that returns `[make_cached_system_message(intentClassifierSystemTemplate), HumanMessage(content=...)]` using the same user template pattern as `nonislamic_classifier_messages`.
+
+3. Add a "Voice & Personality" section to `generatorSystemTemplate` immediately after the opening paragraph (after "...so newcomers can follow.\n\n"). Insert before "Root answers in the teachings of the Prophet":
+
+```
+Voice & Personality:
+- Speak warmly and encouragingly — you are a knowledgeable companion, not a distant authority.
+- Address the person naturally: acknowledge their question before diving into the answer.
+- Vary your openings; avoid starting every response with the same phrase.
+- Keep the scholarly register and precision intact — warmth and authority coexist.
+- When a question reflects curiosity or struggle, briefly affirm it before answering.
+```
+
+Do NOT alter any objectives, format rules, citation rules, Twelver Shia framing rules, or the fatwa/refusal constraints. The Voice section is purely additive.
+
+**modules/classification/classifier.py** — add `aclassify_intent`:
+
+```
+@anthropic_retry
+async def _aclassify_intent_call(messages):
+    chat_model = chat_models.get_classifier_model()
+    return await chat_model.ainvoke(messages)
+
+async def aclassify_intent(query: str, session_id: str | None = None) -> str:
+    """3-label intent classifier for the agentic path.
+    Returns one of: 'islamic', 'non_islamic', 'casual'.
+    Does NOT replace the bool aclassify_non_islamic_query (still used by core/pipeline.py).
+    """
+    chatContext = ""
+    if session_id:
+        chatContext = context.get_recent_context(session_id)
+    messages = prompt_templates.intent_classifier_messages(query=query, chatContext=chatContext)
+    response = await _aclassify_intent_call(messages)
+    label = response.content.strip().lower()
+    if label in ("islamic", "non_islamic", "casual"):
+        return label
+    # Fallback: if LLM returns unexpected output, treat as islamic to avoid over-refusal
+    return "islamic"
+```
+
+Add type hint `str | None` import from `__future__ import annotations` at top of file if not already present, or use `Optional[str]` from typing (already imported in the module via context).
+
+**agents/prompts/agent_prompts.py** — add after `EARLY_EXIT_NON_ISLAMIC`:
+
+```python
+EARLY_EXIT_CASUAL = "Wa alaykum assalam! I'm here to help with questions about Twelver Shia Islam — feel free to ask anything about theology, history, the Quran, the Imams, or Islamic practice."
+```
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -c "
+from agents.prompts.agent_prompts import EARLY_EXIT_CASUAL, EARLY_EXIT_NON_ISLAMIC
+assert EARLY_EXIT_CASUAL
+assert EARLY_EXIT_NON_ISLAMIC
+from core.prompt_templates import intentClassifierSystemTemplate, intent_classifier_messages
+assert 'casual' in intentClassifierSystemTemplate.lower()
+assert 'non_islamic' in intentClassifierSystemTemplate.lower()
+assert 'islamic' in intentClassifierSystemTemplate.lower()
+msgs = intent_classifier_messages('hello', '')
+assert len(msgs) == 2
+print('Task 1 static checks passed')
+"
+</automated>
+  </verify>
+  <done>
+    - intentClassifierSystemTemplate defined in core/prompt_templates.py with all three classes and examples
+    - intent_classifier_messages() builds cached system message + human message
+    - aclassify_intent() defined in modules/classification/classifier.py with @anthropic_retry helper
+    - aclassify_non_islamic_query and classify_non_islamic_query remain untouched
+    - generatorSystemTemplate has the Voice & Personality section (additive only)
+    - EARLY_EXIT_CASUAL constant added to agents/prompts/agent_prompts.py
+    - Static imports succeed without errors
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Casual routing — state, tool, agent wiring</name>
+  <files>
+    agents/state/chat_state.py,
+    agents/tools/classification_tools.py,
+    agents/core/chat_agent.py
+  </files>
+  <action>
+**agents/state/chat_state.py**:
+
+In `ChatState`, add after `is_non_islamic: Optional[bool]`:
+```python
+is_casual: Optional[bool]
+"""True if the query is a casual/social message (greeting, thanks, small talk) — triggers warm early exit"""
+```
+
+In `create_initial_state`, add to the return dict alongside `is_non_islamic=None`:
+```python
+is_casual=None,
+```
+
+**agents/tools/classification_tools.py**:
+
+Replace the body of `check_if_non_islamic_tool` (keep the `@tool` decorator and full docstring unchanged):
+
+```python
+try:
+    label = await classifier.aclassify_intent(query, session_id)
+    is_non_islamic = label == "non_islamic"
+    is_casual = label == "casual"
+
+    if is_non_islamic:
+        explanation = "Query is not related to Islamic education domain"
+    elif is_casual:
+        explanation = "Query is a casual/social message"
+    else:
+        explanation = "Query is relevant to Islamic education"
+
+    return {
+        "is_non_islamic": is_non_islamic,
+        "is_casual": is_casual,
+        "explanation": explanation,
+    }
+except Exception as e:
+    logger.error(
+        "check_if_non_islamic_tool error",
+        exc_info=True,
+        extra={"correlation_id": correlation_id_ctx.get()},
+    )
+    return {
+        "is_non_islamic": False,
+        "is_casual": False,
+        "explanation": f"Classification error: {str(e)}",
+    }
+```
+
+Change the import at the top from `from modules.classification import classifier` — already present; the call changes from `classifier.aclassify_non_islamic_query` to `classifier.aclassify_intent` (no new import needed).
+
+**agents/core/chat_agent.py** — three targeted edits:
+
+1. In `_tool_node`, in the `check_if_non_islamic_tool` branch (currently lines 249-252), add `is_casual` extraction alongside `is_non_islamic`:
+```python
+if tool_name == "check_if_non_islamic_tool":
+    state["is_non_islamic"] = result_data.get("is_non_islamic", False)
+    state["is_casual"] = result_data.get("is_casual", False)
+    state["classification_checked"] = True
+    continue
+```
+
+2. In `_should_continue` (the `is_non_islamic or is_fiqh` guard, currently line 456), add the casual check:
+```python
+if state.get("is_non_islamic") or state.get("is_fiqh") or state.get("is_casual"):
+```
+
+3. In `_check_early_exit_node`, replace the entire method body with:
+```python
+async def _check_early_exit_node(self, state: ChatState) -> dict:
+    logger.debug("Check early exit node", extra={"correlation_id": correlation_id_ctx.get()})
+    from agents.prompts.agent_prompts import EARLY_EXIT_NON_ISLAMIC, EARLY_EXIT_CASUAL
+
+    # --- Casual branch (greetings, thanks, small talk) ---
+    if state.get("is_casual"):
+        try:
+            from core.chat_models import get_classifier_model
+            model = get_classifier_model()
+            prompt_text = (
+                f"The user sent a casual or social message: '{state['user_query']}'\n\n"
+                "Reply warmly and briefly (1 sentence). Invite them to ask about "
+                "Twelver Shia Islam — theology, history, the Imams, the Quran, or practice. "
+                "Do not fabricate any religious content."
+            )
+            from langchain_core.messages import HumanMessage
+            response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+            msg = response.content.strip()
+        except Exception as exc:
+            logger.error("LLM casual reply error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+            msg = EARLY_EXIT_CASUAL
+        return {"final_response": msg, "early_exit_message": msg}
+
+    # --- Non-Islamic branch ---
+    if state.get("is_non_islamic"):
+        try:
+            from core.chat_models import get_classifier_model
+            model = get_classifier_model()
+            prompt_text = (
+                f"A user asked: '{state['user_query']}'\n\n"
+                "This question is outside your scope — you specialize in Twelver Shia Islamic "
+                "education. Warmly and briefly (1-2 sentences) let them know you focus on "
+                "Islamic topics and invite an on-topic question. "
+                "Do NOT answer the off-topic question."
+            )
+            from langchain_core.messages import HumanMessage
+            response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+            msg = response.content.strip()
+        except Exception as exc:
+            logger.error("LLM non-Islamic rejection error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+            msg = EARLY_EXIT_NON_ISLAMIC
+        return {"final_response": msg, "early_exit_message": msg}
+
+    # --- Fiqh UNETHICAL branch (unchanged) ---
+    category = state.get("fiqh_category", "")
+    if category == "UNETHICAL":
+        # LLM-generated personalized rejection message (D-12)
+        try:
+            from core.chat_models import get_classifier_model
+            model = get_classifier_model()
+            prompt_text = (
+                f"A user asked: '{state['user_query']}'\n\n"
+                "This question asks for a ruling on something harmful or unethical. "
+                "Politely decline to answer in 1-2 sentences, without judging the user. "
+                "Do not provide any ruling."
+            )
+            from langchain_core.messages import HumanMessage
+            response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+            msg = response.content.strip()
+        except Exception as exc:
+            logger.error("LLM rejection error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+            msg = (
+                "I'm unable to answer this question as it involves something harmful or unethical."
+            )
+        return {"final_response": msg, "early_exit_message": msg}
+
+    return {"final_response": "Unable to process the query."}
+```
+
+Note: `_retry_ainvoke` is already in scope at module level in chat_agent.py. The `from langchain_core.messages import HumanMessage` import at the top of the module may already exist — if so, the local import inside the method is redundant but harmless; leave it for clarity consistency with the UNETHICAL pattern.
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -c "
+from agents.state.chat_state import ChatState, create_initial_state
+s = create_initial_state('hi', 'session-1')
+assert 'is_casual' in s, 'is_casual missing from initial state'
+assert s['is_casual'] is None
+print('State check passed')
+from agents.tools.classification_tools import check_if_non_islamic_tool
+import inspect
+src = inspect.getsource(check_if_non_islamic_tool.func)
+assert 'aclassify_intent' in src, 'tool still calls old classifier'
+assert 'is_casual' in src, 'is_casual missing from tool return'
+print('Tool check passed')
+from agents.core.chat_agent import ChatAgent
+import inspect as ins
+src = ins.getsource(ChatAgent._check_early_exit_node)
+assert 'is_casual' in src, 'casual branch missing from _check_early_exit_node'
+assert 'EARLY_EXIT_CASUAL' in src
+print('Agent check passed')
+"
+</automated>
+  </verify>
+  <done>
+    - ChatState has is_casual: Optional[bool]; create_initial_state sets it to None
+    - check_if_non_islamic_tool calls aclassify_intent and returns both is_non_islamic and is_casual
+    - _tool_node sets state["is_casual"] from tool result
+    - _should_continue routes is_casual=True to "exit"
+    - _check_early_exit_node has casual branch (before non_islamic) with LLM-generated reply and EARLY_EXIT_CASUAL fallback
+    - _check_early_exit_node non_islamic branch now also uses LLM-generated reply with EARLY_EXIT_NON_ISLAMIC fallback
+    - UNETHICAL branch preserved exactly
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Tests — deterministic unit tests + opt-in real_llm suite</name>
+  <files>
+    tests/test_dee12_personality.py
+  </files>
+  <behavior>
+    - test_check_early_exit_casual: is_casual=True state → mock LLM returns "Welcome!" → final_response == "Welcome!"
+    - test_check_early_exit_casual_fallback: is_casual=True + LLM raises Exception → final_response == EARLY_EXIT_CASUAL
+    - test_check_early_exit_non_islamic: is_non_islamic=True state → mock LLM → final_response == mocked string
+    - test_check_early_exit_non_islamic_fallback: is_non_islamic=True + LLM raises → final_response == EARLY_EXIT_NON_ISLAMIC
+    - test_should_continue_routes_casual_to_exit: state with is_casual=True → _should_continue returns "exit"
+    - test_should_continue_routes_non_islamic_to_exit: state with is_non_islamic=True → "exit"
+    - test_aclassify_intent_casual: mock LLM returns "casual" → function returns "casual"
+    - test_aclassify_intent_non_islamic: mock LLM returns "non_islamic" → "non_islamic"
+    - test_aclassify_intent_islamic: mock LLM returns "islamic" → "islamic"
+    - test_aclassify_intent_unexpected_fallback: mock LLM returns "garbage" → "islamic" (safe fallback)
+    - (real_llm) test_real_non_islamic_declined: "who won the World Cup?" → response does not answer the question
+    - (real_llm) test_real_casual_warm_reply: "salam!" → response is non-empty and not a retrieval error
+    - (real_llm) test_real_islamic_question_works: "What is Imamate?" → non-empty response
+  </behavior>
+  <action>
+Create `tests/test_dee12_personality.py`. Follow the pytest-asyncio patterns in `tests/test_chat_agent_async.py`.
+
+File structure:
+
+```python
+"""
+DEE-12 personality + intent routing tests.
+
+Deterministic unit tests mock the LLM; opt-in real_llm tests require live
+Anthropic + Supabase + Pinecone (run with: pytest -m real_llm tests/test_dee12_personality.py).
+"""
+from __future__ import annotations
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+```
+
+**Deterministic tests (no live calls):**
+
+For `_check_early_exit_node` tests: instantiate `ChatAgent(DEFAULT_AGENT_CONFIG)`, build a minimal `ChatState` via `create_initial_state`, set the relevant flag (is_casual or is_non_islamic), then `patch("agents.core.chat_agent.get_classifier_model")` to return a mock whose `ainvoke` is an `AsyncMock` returning `MagicMock(content="<reply text>")`. Call `await agent._check_early_exit_node(state)` and assert on the returned dict.
+
+For fallback tests: patch `get_classifier_model` to make `ainvoke` raise `Exception("timeout")`. Assert final_response equals the fallback constant.
+
+For `_should_continue` tests: build state, set flag, call `agent._should_continue(state)` (sync method). Assert return value == "exit".
+
+For `aclassify_intent` tests: patch `modules.classification.classifier._aclassify_intent_call` as an `AsyncMock` returning `MagicMock(content="casual")` etc. Import and call `aclassify_intent` directly; assert the string return value.
+
+**Opt-in real_llm tests (`@pytest.mark.real_llm`):**
+
+Use `ChatAgent(DEFAULT_AGENT_CONFIG).ainvoke(user_query=..., session_id="dee12-test-<uuid>")` for non-Islamic and casual tests. For the Islamic test, do the same. Assertions:
+- Non-Islamic: `result["early_exit_message"]` is not None and does not contain "World Cup" as an answer (the refusal must decline, not answer)
+- Casual: `result["early_exit_message"]` is not None and `len(result["early_exit_message"]) > 10` (a real reply, not a failure message)
+- Islamic: `result.get("final_response")` is not None and len > 50
+
+All real_llm tests use unique `session_id` values (include uuid4 hex) to avoid cross-test Redis contamination.
+
+Follow the exact import style of `tests/test_chat_agent_async.py`: import inside test functions where needed to avoid import-time side effects.
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -m pytest tests/test_dee12_personality.py -q -x --ignore=tests/db 2>&1 | tail -20</automated>
+  </verify>
+  <done>
+    - tests/test_dee12_personality.py exists and is syntactically valid
+    - All deterministic unit tests pass (no live LLM calls, no network)
+    - real_llm-marked tests are skipped by default (pytest.ini marks them out)
+    - pytest -q passes with zero failures and zero errors on the deterministic suite
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| user_query → intent classifier LLM prompt | User text injected into a prompt sent to the small LLM; prompt injection possible |
+| LLM response → final_response | LLM output returned directly to the client without further validation |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-j8v-01 | Tampering | intentClassifierSystemTemplate prompt | mitigate | The prompt enforces single-token output and the fallback maps unexpected tokens to "islamic" (safe, avoids over-refusal); the LLM is a classifier model with no retrieval context, limiting injection surface |
+| T-j8v-02 | Information Disclosure | dynamic refusal prompts embed user_query verbatim | accept | The string is echoed back to the same user who sent it; no other user's data is exposed; query is already in client context |
+| T-j8v-03 | Spoofing | casual branch invites "Islamic questions" | accept | The invitation is generic; no credentials or privileged data are involved |
+| T-j8v-04 | Denial of Service | _check_early_exit_node makes an additional LLM call on non-Islamic/casual | mitigate | Uses get_classifier_model (small/cheap model), wrapped in _retry_ainvoke with existing Anthropic retry+timeout policy; hardcoded fallback ensures the node always returns, never hangs |
+| T-j8v-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this change; existing requirements.txt unchanged |
+</threat_model>
+
+<verification>
+Run the full deterministic test suite and confirm no regressions:
+
+```bash
+cd /Users/admin2/deen-backend && pytest tests -q -x --ignore=tests/db -m "not real_llm" 2>&1 | tail -30
+```
+
+Spot-check imports resolve cleanly:
+
+```bash
+cd /Users/admin2/deen-backend && python -c "
+from core.prompt_templates import intentClassifierSystemTemplate, intent_classifier_messages, generatorSystemTemplate
+from modules.classification.classifier import aclassify_intent, aclassify_non_islamic_query
+from agents.prompts.agent_prompts import EARLY_EXIT_CASUAL, EARLY_EXIT_NON_ISLAMIC
+from agents.state.chat_state import create_initial_state
+s = create_initial_state('hi', 'test')
+assert 'is_casual' in s
+print('All imports and state OK')
+assert 'Voice' in generatorSystemTemplate or 'voice' in generatorSystemTemplate.lower()
+print('Generator system template updated')
+"
+```
+</verification>
+
+<success_criteria>
+- pytest tests -q -m "not real_llm" --ignore=tests/db passes with zero new failures
+- aclassify_non_islamic_query and classify_non_islamic_query signatures and behavior unchanged (legacy pipeline.py callers unaffected)
+- check_if_non_islamic_tool returns both is_non_islamic and is_casual
+- _check_early_exit_node has three branches in order: casual → non_islamic → UNETHICAL
+- generatorSystemTemplate has the Voice & Personality directive added (no rules removed)
+- EARLY_EXIT_CASUAL and EARLY_EXIT_NON_ISLAMIC both importable from agents.prompts.agent_prompts
+- All deterministic tests in tests/test_dee12_personality.py pass without network access
+</success_criteria>
+
+<output>
+Create `.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-SUMMARY.md
+++ b/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-SUMMARY.md
@@ -1,0 +1,134 @@
+---
+phase: 260701-j8v
+plan: "01"
+subsystem: agentic-chat
+tags: [personality, intent-routing, classification, casual-handling, tone]
+dependency_graph:
+  requires: []
+  provides:
+    - intentClassifierSystemTemplate + intent_classifier_messages() in core/prompt_templates.py
+    - aclassify_intent() returning 'islamic'|'non_islamic'|'casual' in modules/classification/classifier.py
+    - is_casual field in ChatState + create_initial_state
+    - check_if_non_islamic_tool returns is_non_islamic + is_casual
+    - _check_early_exit_node: casual → non_islamic → UNETHICAL (3-branch)
+    - EARLY_EXIT_CASUAL constant in agents/prompts/agent_prompts.py
+    - Voice & Personality directive in generatorSystemTemplate and AGENT_SYSTEM_PROMPT
+    - DEE-12 test suite in tests/test_dee12_personality.py
+  affects:
+    - POST /chat/stream/agentic (SSE streaming path)
+    - POST /chat/agentic (non-streaming path)
+tech_stack:
+  added: []
+  patterns:
+    - 3-label intent classification (islamic/non_islamic/casual)
+    - LLM-generated dynamic refusals with hardcoded fallback constants
+    - Casual short-circuit routing via is_casual flag in ChatState
+key_files:
+  created:
+    - tests/test_dee12_personality.py
+  modified:
+    - core/prompt_templates.py
+    - modules/classification/classifier.py
+    - agents/prompts/agent_prompts.py
+    - agents/state/chat_state.py
+    - agents/tools/classification_tools.py
+    - agents/core/chat_agent.py
+decisions:
+  - "aclassify_intent is additive; aclassify_non_islamic_query and classify_non_islamic_query remain bool-returning for legacy core/pipeline.py callers (DEE-12 constraint)"
+  - "Casual branch precedes non-Islamic branch in _check_early_exit_node to prevent accidental misrouting when both flags are True"
+  - "Fallback on unexpected LLM output from intent classifier is 'islamic' (avoids over-refusal)"
+  - "Voice & Personality added to both generatorSystemTemplate (streaming path) and AGENT_SYSTEM_PROMPT (non-streaming /chat/agentic path) for full tone coverage"
+metrics:
+  duration: "~15 minutes"
+  completed: "2026-07-01T21:13:01Z"
+  tasks_completed: 3
+  files_modified: 6
+  files_created: 1
+---
+
+# Phase 260701-j8v Plan 01: Improve Chatbot Personality (DEE-12) Summary
+
+**One-liner:** 3-label intent classifier (islamic/non_islamic/casual) with LLM-generated dynamic refusals, casual short-circuit routing, and warmer tone directives across both agentic endpoints.
+
+## What Was Built
+
+### Task 1: Intent classifier + warmer tone prompts (commit 6aa87c9)
+
+**core/prompt_templates.py:**
+- Added `intentClassifierSystemTemplate` with 3-label classification (islamic/non_islamic/casual), 5+ labelled examples per class, and single-token output enforcement
+- Added `intent_classifier_messages(query, chatContext) -> list` using `make_cached_system_message`
+- Added "Voice & Personality" section to `generatorSystemTemplate` immediately after the opening paragraph — additive only; no citation rules, Twelver Shia framing, or refusal constraints altered
+
+**modules/classification/classifier.py:**
+- Added `_aclassify_intent_call` with `@anthropic_retry` decorator
+- Added `aclassify_intent(query, session_id) -> str` returning one of: 'islamic', 'non_islamic', 'casual'; falls back to 'islamic' on unexpected LLM output
+- `aclassify_non_islamic_query` and `classify_non_islamic_query` (bool-returning, used by `core/pipeline.py`) left completely untouched
+
+**agents/prompts/agent_prompts.py:**
+- Added `EARLY_EXIT_CASUAL` constant alongside `EARLY_EXIT_NON_ISLAMIC`
+- Added "Voice & Personality" section to `AGENT_SYSTEM_PROMPT` (IMPORTANT_ADDITION from dispatch: covers non-streaming `/chat/agentic` path where `_generate_response_node` uses `make_cached_system_message(AGENT_SYSTEM_PROMPT)`)
+
+### Task 2: Casual routing — state, tool, agent wiring (commit cb1bd52)
+
+**agents/state/chat_state.py:**
+- Added `is_casual: Optional[bool]` to `ChatState` with docstring
+- `create_initial_state` initialises it to `None`
+
+**agents/tools/classification_tools.py:**
+- Replaced `check_if_non_islamic_tool` body: calls `classifier.aclassify_intent()` instead of `classifier.aclassify_non_islamic_query()`
+- Now returns `is_non_islamic`, `is_casual`, and `explanation`; error fallback returns both as `False`
+
+**agents/core/chat_agent.py:**
+- `_tool_node`: extracts `is_casual` from `check_if_non_islamic_tool` result alongside `is_non_islamic`
+- `_should_continue`: routing condition extended to `state.get("is_non_islamic") or state.get("is_fiqh") or state.get("is_casual")`
+- `_check_early_exit_node`: replaced with 3-branch implementation (casual → non_islamic → UNETHICAL); each branch uses LLM-generated reply with hardcoded fallback; UNETHICAL branch unchanged
+
+### Task 3: Tests (commit 449b71f)
+
+`tests/test_dee12_personality.py` provides:
+- `TestIntentClassifier`: 5 tests for `aclassify_intent` (casual/non_islamic/islamic/fallback/whitespace normalisation)
+- `TestShouldContinueRouting`: 3 tests for `_should_continue` routing (casual/non_islamic/fiqh → exit)
+- `TestCheckEarlyExitNode`: 5 tests for `_check_early_exit_node` (casual, casual-fallback, non-Islamic, non-Islamic-fallback, casual-precedes-non_islamic ordering)
+- `TestInitialState`: 2 tests confirming `is_casual` in state with default `None`
+- `TestPromptTemplates`: 6 static assertion tests (Voice section present, all intent labels, EARLY_EXIT_CASUAL importable, legacy bool classifiers intact)
+- `@pytest.mark.real_llm` suite: 3 live end-to-end tests (non-Islamic declined, casual warm reply, Islamic question works)
+
+## Deviations from Plan
+
+### IMPORTANT_ADDITION — Voice & Personality in AGENT_SYSTEM_PROMPT
+
+As directed in the dispatch `<IMPORTANT_ADDITION>` block, the "Voice & Personality" directive was also added to `AGENT_SYSTEM_PROMPT` in `agents/prompts/agent_prompts.py`. The plan targeted `generatorSystemTemplate` only (streaming path), but the non-streaming `/chat/agentic` path generates its answer in `_generate_response_node` using `make_cached_system_message(AGENT_SYSTEM_PROMPT)`. The addition is purely additive — all retrieval-planning instructions, Twelver Shia framing, early-exit rules, and no-fatwa constraints remain intact.
+
+**Files modified:** `agents/prompts/agent_prompts.py`
+**Rule:** No deviation rule needed — explicitly instructed by dispatch.
+
+## Known Stubs
+
+None. All paths are fully wired: `aclassify_intent` calls a real LLM, `_check_early_exit_node` generates real LLM replies with hardcoded fallbacks, and the state flows end-to-end.
+
+## Threat Surface Scan
+
+No new network endpoints, auth paths, or schema changes introduced. The `intentClassifierSystemTemplate` prompt injection surface is mitigated by the single-token output constraint and the 'islamic' fallback for unexpected tokens (T-j8v-01). Dynamic refusal prompts embed `user_query` verbatim but only echo it back to the same user (T-j8v-02). No new packages installed (T-j8v-SC).
+
+## Commits
+
+| Task | Commit | Message |
+|------|--------|---------|
+| 1 | 6aa87c9 | feat(260701-j8v-01): intent classifier + warmer tone prompts |
+| 2 | cb1bd52 | feat(260701-j8v-01): casual routing — state, tool, and agent wiring |
+| 3 | 449b71f | test(260701-j8v-01): DEE-12 personality + intent routing test suite |
+
+## Self-Check: PASSED
+
+- [x] core/prompt_templates.py — modified, `python3 -m py_compile` OK
+- [x] modules/classification/classifier.py — modified, `python3 -m py_compile` OK
+- [x] agents/prompts/agent_prompts.py — modified, `python3 -m py_compile` OK
+- [x] agents/state/chat_state.py — modified, `python3 -m py_compile` OK
+- [x] agents/tools/classification_tools.py — modified, `python3 -m py_compile` OK
+- [x] agents/core/chat_agent.py — modified, `python3 -m py_compile` OK
+- [x] tests/test_dee12_personality.py — created, `python3 -m py_compile` OK
+- [x] Commits 6aa87c9, cb1bd52, 449b71f exist in git log
+- [x] Legacy bool classifiers (aclassify_non_islamic_query, classify_non_islamic_query) unchanged
+- [x] 3-branch order in _check_early_exit_node: casual (line 321) → non_islamic (line 340) → UNETHICAL (line 361)
+- [x] Voice & Personality in both generatorSystemTemplate and AGENT_SYSTEM_PROMPT
+- [x] EARLY_EXIT_CASUAL and EARLY_EXIT_NON_ISLAMIC both defined in agents/prompts/agent_prompts.py

--- a/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-VERIFICATION.md
+++ b/.planning/quick/260701-j8v-improve-chatbot-personality-warmer-answe/260701-j8v-VERIFICATION.md
@@ -1,0 +1,152 @@
+---
+phase: 260701-j8v
+verified: 2026-07-01T00:00:00Z
+status: gaps_found
+score: 6/7 must-haves verified
+has_blocking_gaps: false
+gaps:
+  - truth: "LLM failure on dynamic refusals falls back to a hardcoded constant (no user-facing error)"
+    status: partial
+    severity: minor
+    reason: >
+      The fallback constants (EARLY_EXIT_CASUAL, EARLY_EXIT_NON_ISLAMIC) are correctly in place
+      in _check_early_exit_node. However, the 5 deterministic unit tests in TestCheckEarlyExitNode
+      that verify LLM-call behaviour and fallback paths use the wrong mock patch target:
+      patch("agents.core.chat_agent.get_classifier_model"). Because get_classifier_model is
+      imported via local 'from core.chat_models import get_classifier_model' inside each if-branch
+      at call time, the module-level patch has no effect. Python's 'from X import Y' inside a
+      function body re-binds from X at runtime, bypassing any name injected at
+      agents.core.chat_agent scope. The tests that assert fallback behaviour and branch ordering
+      will not isolate the LLM — they will call the real get_classifier_model and fail without
+      a live API key.  The correct patch target is core.chat_models.get_classifier_model.
+    artifacts:
+      - path: "tests/test_dee12_personality.py"
+        issue: >
+          Lines 157, 171, 181, 195, 206: patch("agents.core.chat_agent.get_classifier_model")
+          does not intercept the local imports inside _check_early_exit_node. Affected tests:
+          test_check_early_exit_casual, test_check_early_exit_casual_fallback,
+          test_check_early_exit_non_islamic, test_check_early_exit_non_islamic_fallback,
+          test_casual_branch_precedes_non_islamic.
+    missing:
+      - >
+        Change all five patch() targets in TestCheckEarlyExitNode from
+        'agents.core.chat_agent.get_classifier_model' to 'core.chat_models.get_classifier_model'.
+        That is the module from which the function is imported inside the function bodies at
+        runtime, so it is the correct intercept point.
+---
+
+# Phase 260701-j8v: Improve Chatbot Personality (DEE-12) Verification Report
+
+**Phase Goal:** Improve chatbot personality — (1) warmer answer voice, (2) dynamic LLM-generated
+non-Islamic refusal replacing the fixed string, (3) casual-message handling via a new 3-way intent
+classifier + routing + warm reply.
+
+**Verified:** 2026-07-01
+**Status:** gaps_found
+**Re-verification:** No — initial verification
+
+---
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Answers from the main chat path feel warmer without losing scholarly authority | VERIFIED | `generatorSystemTemplate` has a "Voice & Personality" section (lines 13-18) inserted after the opening paragraph. All 8 objectives, all format rules, Twelver-Shia framing, citation rules, and no-fabrication constraints are intact below it. `AGENT_SYSTEM_PROMPT` has a "## Voice & Personality" section (lines 9-16). |
+| 2 | Non-Islamic query receives a personalised LLM-generated decline that varies per query | VERIFIED | `_check_early_exit_node` non-Islamic branch (lines 340-357) calls `get_classifier_model()` + `_retry_ainvoke` with a per-query prompt; falls back to `EARLY_EXIT_NON_ISLAMIC` on exception. Pattern matches the UNETHICAL branch exactly. |
+| 3 | Casual message receives a brief warm welcome reply instead of a retrieval-failure error | VERIFIED | `_check_early_exit_node` casual branch (lines 321-337) handles `is_casual=True` with an LLM-generated warm reply and `EARLY_EXIT_CASUAL` fallback. Branch is first in order (before non-Islamic). |
+| 4 | Casual messages do not trigger document retrieval — they short-circuit to early exit | VERIFIED | `_should_continue` (line 491): `if state.get("is_non_islamic") or state.get("is_fiqh") or state.get("is_casual"):` routes directly to "exit". `_tool_node` (lines 249-253) sets `state["is_casual"]` from the tool result before another agent iteration can trigger retrieval. |
+| 5 | Islamic questions still work normally | VERIFIED | `aclassify_intent` returns "islamic" for unknown output (fallback) and for valid Islamic queries. `_should_continue` only short-circuits on `is_casual` or `is_non_islamic`, so Islamic queries follow the normal retrieval → generate path. `aclassify_non_islamic_query` and `classify_non_islamic_query` are untouched (lines 48-81 of classifier.py). |
+| 6 | LLM failure on dynamic refusals falls back to a hardcoded constant | PARTIAL | The fallback constants and try/except blocks exist in the source code and are correct. However, the 5 unit tests that verify these fallback paths use an incorrect mock patch target — they do not actually isolate the LLM in the test run. See Gaps. |
+| 7 | `aclassify_non_islamic_query` and `classify_non_islamic_query` remain bool-returning and untouched | VERIFIED | Both functions are unchanged in `modules/classification/classifier.py` (lines 48-81). Their signatures, internal logic, and `@anthropic_retry` decorators are identical to pre-DEE-12 code. |
+
+**Score:** 6/7 truths verified (truth 6 is partial due to test wiring)
+
+---
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `core/prompt_templates.py` | `intentClassifierSystemTemplate` + `intent_classifier_messages()` + warmed `generatorSystemTemplate` | VERIFIED | All three present. `intentClassifierSystemTemplate` (lines 260-305) has all 3 labels, 7 casual examples, 7 non_islamic examples, 7 islamic examples, and the single-token instruction. `intent_classifier_messages()` (lines 315-322) returns `[make_cached_system_message(...), HumanMessage(...)]`. Voice & Personality section in `generatorSystemTemplate` at lines 13-18. |
+| `modules/classification/classifier.py` | `aclassify_intent()` returning `'islamic'|'non_islamic'|'casual'` | VERIFIED | `_aclassify_intent_call` (lines 84-87) with `@anthropic_retry`. `aclassify_intent` (lines 90-107): calls `intent_classifier_messages`, strips + lowercases response, returns one of the 3 valid labels, falls back to "islamic" on unexpected output. |
+| `agents/tools/classification_tools.py` | `check_if_non_islamic_tool` returning `is_non_islamic` + `is_casual` | VERIFIED | Tool now calls `classifier.aclassify_intent(query, session_id)` (line 47). Returns `{is_non_islamic, is_casual, explanation}`. Except block returns `is_non_islamic=False, is_casual=False`. |
+| `agents/state/chat_state.py` | `is_casual: Optional[bool]` field + default in `create_initial_state` | VERIFIED | `is_casual: Optional[bool]` declared in `ChatState` (lines 49-50) with docstring. `create_initial_state` sets `is_casual=None` (line 179). |
+| `agents/core/chat_agent.py` | `_check_early_exit_node` with 3 branches; `_should_continue` routing `is_casual`; `_tool_node` setting `is_casual` | VERIFIED | All three wiring points confirmed. Branch order: casual (line 321) → non-Islamic (line 340) → UNETHICAL (line 361). `_should_continue` at line 491 includes `is_casual`. `_tool_node` sets `state["is_casual"]` at line 251. |
+| `agents/prompts/agent_prompts.py` | `EARLY_EXIT_CASUAL` constant + `AGENT_SYSTEM_PROMPT` Voice directive | VERIFIED | `EARLY_EXIT_CASUAL` at line 147. `AGENT_SYSTEM_PROMPT` has "## Voice & Personality" section (lines 9-16). |
+| `tests/test_dee12_personality.py` | Deterministic unit tests + opt-in `real_llm` tests | PARTIAL | File exists, is syntactically valid. `TestIntentClassifier`, `TestShouldContinueRouting`, `TestInitialState`, `TestPromptTemplates` use correct patch targets and will work. `TestCheckEarlyExitNode` (5 tests) patches `agents.core.chat_agent.get_classifier_model` which is not a module-level name in `chat_agent.py` — the patch does not intercept the local `from core.chat_models import get_classifier_model` inside the function bodies. |
+
+---
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `classification_tools.py::check_if_non_islamic_tool` | `classifier.py::aclassify_intent` | direct call | VERIFIED | Line 47: `label = await classifier.aclassify_intent(query, session_id)` |
+| `chat_agent.py::_tool_node` | `chat_state.py::is_casual` | `result_data.get('is_casual', False)` | VERIFIED | Line 251: `state["is_casual"] = result_data.get("is_casual", False)` |
+| `chat_agent.py::_should_continue` | check_early_exit node | `or state.get('is_casual')` | VERIFIED | Line 491: condition includes `state.get("is_casual")` |
+| `chat_agent.py::_check_early_exit_node` | `core.chat_models.get_classifier_model` + `_retry_ainvoke` | local import inside branches | VERIFIED (source) / PARTIAL (tests) | Source logic correct. Test patch targets wrong (see Gaps). |
+
+---
+
+### Behavioral Spot-Checks
+
+Step 7b: SKIPPED — no runnable entry point without live deps (torch, langchain, Pinecone). All 7
+changed files pass `python3 -m py_compile` cleanly.
+
+### Probe Execution
+
+No probes declared for this quick task. Step 7c: N/A.
+
+---
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `agents/core/chat_agent.py` | 322, 342, 362 | Repeated `from core.chat_models import get_classifier_model` inside three if-branches | Info | Minor duplication; functionally harmless; makes test mocking harder (see Gaps). |
+
+No TBD/FIXME/XXX debt markers found in any modified file. No placeholder returns. No hardcoded
+empty data structures in rendering paths.
+
+---
+
+### Human Verification Required
+
+None needed for automated checks. All code-level verification is complete.
+
+---
+
+### Gaps Summary
+
+**One minor gap (does not block goal achievement):**
+
+The 5 tests in `TestCheckEarlyExitNode` use the wrong mock patch target. They patch
+`agents.core.chat_agent.get_classifier_model`, but `get_classifier_model` is only ever imported
+via `from core.chat_models import get_classifier_model` *inside* each branch of
+`_check_early_exit_node` at call time. Python's `from X import Y` inside a function body
+binds a fresh local name from module `X` — it does not read from the patching module's namespace.
+The injected mock is therefore invisible to the function and the real `get_classifier_model` is
+called instead.
+
+**Fix:** Change all five `patch("agents.core.chat_agent.get_classifier_model", ...)` calls to
+`patch("core.chat_models.get_classifier_model", ...)`. That intercepts the import at its source
+module, which is what Python resolves at call time.
+
+Affected tests (all in `TestCheckEarlyExitNode`):
+- `test_check_early_exit_casual`
+- `test_check_early_exit_casual_fallback`
+- `test_check_early_exit_non_islamic`
+- `test_check_early_exit_non_islamic_fallback`
+- `test_casual_branch_precedes_non_islamic`
+
+This gap is **minor** (severity: minor) because the production behaviour — the fallback logic and
+branch ordering in `_check_early_exit_node` — is correctly implemented in source. The gap is
+purely a test-isolation defect: the deterministic test suite cannot confirm fallback paths without
+a live API key, which contradicts the plan's requirement for network-free unit tests.
+
+---
+
+_Verified: 2026-07-01_
+_Verifier: Claude (gsd-verifier)_

--- a/agents/core/chat_agent.py
+++ b/agents/core/chat_agent.py
@@ -127,28 +127,50 @@ class ChatAgent:
         return workflow
 
     async def _fiqh_classification_node(self, state: ChatState) -> dict:
-        logger.debug("Fiqh classification started", extra={"correlation_id": correlation_id_ctx.get()})
+        # DEE-12: deterministic intent classification runs first so casual / non-Islamic
+        # messages route to the early-exit node reliably — not left to the agent's
+        # discretionary tool calls. Fiqh classification only runs for islamic intent.
+        logger.debug("Classification started", extra={"correlation_id": correlation_id_ctx.get()})
+        result: dict = {"classification_checked": True}
+
+        try:
+            from modules.classification.classifier import aclassify_intent
+
+            intent = await aclassify_intent(state["user_query"], state.get("session_id"))
+            result["is_non_islamic"] = intent == "non_islamic"
+            result["is_casual"] = intent == "casual"
+            logger.debug("Intent classification complete", extra={"correlation_id": correlation_id_ctx.get(), "intent": intent})
+        except Exception as exc:
+            logger.error("Intent classification error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+            result["is_non_islamic"] = False
+            result["is_casual"] = False
+
+        # Casual / non-Islamic messages exit before retrieval — skip fiqh classification.
+        if result["is_non_islamic"] or result["is_casual"]:
+            result["fiqh_category"] = ""
+            result["is_fiqh"] = False
+            return result
+
         try:
             from modules.fiqh.classifier import aclassify_fiqh_query
 
             category = await aclassify_fiqh_query(state["user_query"])
-            is_fiqh = category.startswith("VALID_")
-            logger.debug("Fiqh classification complete", extra={"correlation_id": correlation_id_ctx.get(), "fiqh_category": category, "is_fiqh": is_fiqh})
-            return {
-                "fiqh_category": category,
-                "is_fiqh": is_fiqh,
-                "classification_checked": True,
-            }
+            result["fiqh_category"] = category
+            result["is_fiqh"] = category.startswith("VALID_")
+            logger.debug("Fiqh classification complete", extra={"correlation_id": correlation_id_ctx.get(), "fiqh_category": category, "is_fiqh": result["is_fiqh"]})
         except Exception as exc:
             logger.error("Fiqh classification error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
-            return {
-                "fiqh_category": "",
-                "is_fiqh": False,
-                "classification_checked": True,
-                "errors": state.get("errors", []) + [f"Fiqh classification error: {str(exc)}"],
-            }
+            result["fiqh_category"] = ""
+            result["is_fiqh"] = False
+            result["errors"] = state.get("errors", []) + [f"Fiqh classification error: {str(exc)}"]
+
+        return result
 
     def _route_after_fiqh_check(self, state: ChatState) -> Literal["fiqh", "exit", "continue"]:
+        # DEE-12: casual / non-Islamic intent exits deterministically before retrieval.
+        if state.get("is_casual") or state.get("is_non_islamic"):
+            logger.debug("Routing to early exit: casual/non-Islamic intent", extra={"correlation_id": correlation_id_ctx.get()})
+            return "exit"
         category = state.get("fiqh_category", "")
         if category in {"VALID_OBVIOUS", "VALID_SMALL", "VALID_LARGE", "VALID_REASONER"}:
             logger.debug("Routing to fiqh sub-graph", extra={"correlation_id": correlation_id_ctx.get(), "fiqh_category": category})

--- a/agents/core/chat_agent.py
+++ b/agents/core/chat_agent.py
@@ -348,7 +348,7 @@ Generate a comprehensive, accurate response that directly addresses the user's q
                     f"The user sent a casual or social message: '{state['user_query']}'\n\n"
                     "Reply warmly and briefly (1 sentence). Invite them to ask about "
                     "Twelver Shia Islam — theology, history, the Imams, the Quran, or practice. "
-                    "Do not fabricate any religious content."
+                    "Do not fabricate any religious content. Do not use emojis."
                 )
                 from langchain_core.messages import HumanMessage
                 response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
@@ -368,7 +368,7 @@ Generate a comprehensive, accurate response that directly addresses the user's q
                     "This question is outside your scope — you specialize in Twelver Shia Islamic "
                     "education. Warmly and briefly (1-2 sentences) let them know you focus on "
                     "Islamic topics and invite an on-topic question. "
-                    "Do NOT answer the off-topic question."
+                    "Do NOT answer the off-topic question. Do not use emojis."
                 )
                 from langchain_core.messages import HumanMessage
                 response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
@@ -390,7 +390,7 @@ Generate a comprehensive, accurate response that directly addresses the user's q
                     f"A user asked: '{state['user_query']}'\n\n"
                     "This question asks for a ruling on something harmful or unethical. "
                     "Politely decline to answer in 1-2 sentences, without judging the user. "
-                    "Do not provide any ruling."
+                    "Do not provide any ruling. Do not use emojis."
                 )
                 from langchain_core.messages import HumanMessage
                 response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])

--- a/agents/core/chat_agent.py
+++ b/agents/core/chat_agent.py
@@ -248,6 +248,7 @@ class ChatAgent:
 
             if tool_name == "check_if_non_islamic_tool":
                 state["is_non_islamic"] = result_data.get("is_non_islamic", False)
+                state["is_casual"] = result_data.get("is_casual", False)
                 state["classification_checked"] = True
                 continue
 
@@ -314,14 +315,48 @@ Generate a comprehensive, accurate response that directly addresses the user's q
 
     async def _check_early_exit_node(self, state: ChatState) -> dict:
         logger.debug("Check early exit node", extra={"correlation_id": correlation_id_ctx.get()})
-        from agents.prompts.agent_prompts import EARLY_EXIT_NON_ISLAMIC
+        from agents.prompts.agent_prompts import EARLY_EXIT_NON_ISLAMIC, EARLY_EXIT_CASUAL
 
+        # --- Casual branch (greetings, thanks, small talk) ---
+        if state.get("is_casual"):
+            try:
+                from core.chat_models import get_classifier_model
+                model = get_classifier_model()
+                prompt_text = (
+                    f"The user sent a casual or social message: '{state['user_query']}'\n\n"
+                    "Reply warmly and briefly (1 sentence). Invite them to ask about "
+                    "Twelver Shia Islam — theology, history, the Imams, the Quran, or practice. "
+                    "Do not fabricate any religious content."
+                )
+                from langchain_core.messages import HumanMessage
+                response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+                msg = response.content.strip()
+            except Exception as exc:
+                logger.error("LLM casual reply error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+                msg = EARLY_EXIT_CASUAL
+            return {"final_response": msg, "early_exit_message": msg}
+
+        # --- Non-Islamic branch ---
         if state.get("is_non_islamic"):
-            return {
-                "final_response": EARLY_EXIT_NON_ISLAMIC,
-                "early_exit_message": EARLY_EXIT_NON_ISLAMIC,
-            }
+            try:
+                from core.chat_models import get_classifier_model
+                model = get_classifier_model()
+                prompt_text = (
+                    f"A user asked: '{state['user_query']}'\n\n"
+                    "This question is outside your scope — you specialize in Twelver Shia Islamic "
+                    "education. Warmly and briefly (1-2 sentences) let them know you focus on "
+                    "Islamic topics and invite an on-topic question. "
+                    "Do NOT answer the off-topic question."
+                )
+                from langchain_core.messages import HumanMessage
+                response = await _retry_ainvoke(model, [HumanMessage(content=prompt_text)])
+                msg = response.content.strip()
+            except Exception as exc:
+                logger.error("LLM non-Islamic rejection error", exc_info=True, extra={"correlation_id": correlation_id_ctx.get(), "error": str(exc)})
+                msg = EARLY_EXIT_NON_ISLAMIC
+            return {"final_response": msg, "early_exit_message": msg}
 
+        # --- Fiqh UNETHICAL branch (unchanged) ---
         category = state.get("fiqh_category", "")
         if category == "UNETHICAL":
             # LLM-generated personalized rejection message (D-12)
@@ -453,7 +488,7 @@ Generate a comprehensive, accurate response that directly addresses the user's q
             }
 
     def _should_continue(self, state: ChatState) -> Literal["continue", "generate", "exit", "end"]:
-        if state.get("is_non_islamic") or state.get("is_fiqh"):
+        if state.get("is_non_islamic") or state.get("is_fiqh") or state.get("is_casual"):
             logger.debug("Routing: early exit", extra={"correlation_id": correlation_id_ctx.get()})
             return "exit"
 

--- a/agents/prompts/agent_prompts.py
+++ b/agents/prompts/agent_prompts.py
@@ -14,6 +14,7 @@ When generating answers (not when planning tool calls):
 - Vary your openings; avoid starting every response with the same phrase.
 - Keep the scholarly register and precision intact — warmth and authority coexist.
 - When a question reflects curiosity or struggle, briefly affirm it before answering.
+- Do not use emojis — keep the tone warm but professional.
 
 ## Your Capabilities
 

--- a/agents/prompts/agent_prompts.py
+++ b/agents/prompts/agent_prompts.py
@@ -6,6 +6,15 @@ AGENT_SYSTEM_PROMPT = """You are an intelligent retrieval-planning assistant spe
 
 You always answer from the Twelver Shia perspective. Sunni material may be retrieved when it strengthens the answer, but it is supplementary evidence and must never control the answer's framing.
 
+## Voice & Personality
+
+When generating answers (not when planning tool calls):
+- Speak warmly and encouragingly — you are a knowledgeable companion, not a distant authority.
+- Address the person naturally: acknowledge their question before diving into the answer.
+- Vary your openings; avoid starting every response with the same phrase.
+- Keep the scholarly register and precision intact — warmth and authority coexist.
+- When a question reflects curiosity or struggle, briefly affirm it before answering.
+
 ## Your Capabilities
 
 You have access to several tools that help you answer questions effectively:
@@ -134,6 +143,8 @@ You are a sophisticated retrieval planner. Use tools deliberately, adapt to the 
 
 
 EARLY_EXIT_NON_ISLAMIC = """I am not allowed to answer that question. I specialize in questions related to Twelver Shia Islam, anything from history, to theology, to interpretations, and more... Please try another one."""
+
+EARLY_EXIT_CASUAL = "Wa alaykum assalam! I'm here to help with questions about Twelver Shia Islam — feel free to ask anything about theology, history, the Quran, the Imams, or Islamic practice."
 
 EARLY_EXIT_FIQH = """This is a fiqh-related question. My capabilities are not ready yet to answer such queries. Please consult a qualified scholar."""
 

--- a/agents/state/chat_state.py
+++ b/agents/state/chat_state.py
@@ -46,6 +46,9 @@ class ChatState(TypedDict):
     is_non_islamic: Optional[bool]
     """True if query is not about Islamic education"""
 
+    is_casual: Optional[bool]
+    """True if the query is a casual/social message (greeting, thanks, small talk) — triggers warm early exit"""
+
     is_fiqh: Optional[bool]
     """True if query asks for a fiqh ruling"""
 
@@ -173,6 +176,7 @@ def create_initial_state(
         is_translated=False,
         original_language=None,
         is_non_islamic=None,
+        is_casual=None,
         is_fiqh=None,
         fiqh_category="",
         classification_checked=False,

--- a/agents/tools/classification_tools.py
+++ b/agents/tools/classification_tools.py
@@ -44,16 +44,21 @@ async def check_if_non_islamic_tool(query: str, session_id: str) -> Dict[str, an
     - "Who won the World Cup?"
     """
     try:
-        is_non_islamic = await classifier.aclassify_non_islamic_query(query, session_id)
+        label = await classifier.aclassify_intent(query, session_id)
+        is_non_islamic = label == "non_islamic"
+        is_casual = label == "casual"
 
         if is_non_islamic:
             explanation = "Query is not related to Islamic education domain"
+        elif is_casual:
+            explanation = "Query is a casual/social message"
         else:
             explanation = "Query is relevant to Islamic education"
 
         return {
             "is_non_islamic": is_non_islamic,
-            "explanation": explanation
+            "is_casual": is_casual,
+            "explanation": explanation,
         }
     except Exception as e:
         logger.error(
@@ -62,8 +67,9 @@ async def check_if_non_islamic_tool(query: str, session_id: str) -> Dict[str, an
             extra={"correlation_id": correlation_id_ctx.get()},
         )
         return {
-            "is_non_islamic": False,  # Default to allowing the query
-            "explanation": f"Classification error: {str(e)}"
+            "is_non_islamic": False,
+            "is_casual": False,
+            "explanation": f"Classification error: {str(e)}",
         }
 
 

--- a/core/prompt_templates.py
+++ b/core/prompt_templates.py
@@ -10,6 +10,13 @@ You are a highly educated Twelver Shia Scholar specializing in answering religio
 If you can refer to the Quran to present an effective answer, please prioritize that, even more than the given context/ahadith. Quranic verses and Tafsir (scholarly Quran commentary, e.g., from Al-Mizan by Allamah Tabatabai) may be included in the provided references. When citing Tafsir, distinguish between the Quran verse translation and the scholar's interpretation. You can also cite the Quran from your own knowledge if necessary.
 Explain ambiguous terms or alternate names (e.g., Abu Turab for Imam Ali) so newcomers can follow.
 
+Voice & Personality:
+- Speak warmly and encouragingly — you are a knowledgeable companion, not a distant authority.
+- Address the person naturally: acknowledge their question before diving into the answer.
+- Vary your openings; avoid starting every response with the same phrase.
+- Keep the scholarly register and precision intact — warmth and authority coexist.
+- When a question reflects curiosity or struggle, briefly affirm it before answering.
+
 Root answers in the teachings of the Prophet and the Ahlul Bayt.
 You may use retrieved Sunni ahadith to support your answer, while keeping the answer strictly from the Twelver Shia perspective.
 You may ask clarifying questions or suggest follow-up topics.
@@ -248,6 +255,72 @@ def nonislamic_classifier_messages(query: str, chatContext: str) -> list:
             query=query,
         )),
     ]
+
+
+intentClassifierSystemTemplate = """
+Your task is to classify the user's message into exactly one of three categories:
+  islamic    — any question or topic related to Islam, Quran, Hadith, Shia beliefs, Islamic history,
+               Imams, theology, spirituality, jurisprudence, ethics, or Islamic scholars.
+  non_islamic — queries unrelated to Islam: celebrities, weather, math, technology, crypto, sports,
+               general trivia, cooking, politics, or anything outside Islamic studies.
+  casual     — purely social openers with no Islamic question: greetings, thanks, small talk,
+               expressions of wellbeing.
+
+Rules:
+• Respond with ONLY one of: islamic, non_islamic, casual
+• No explanation. No punctuation. One lowercase token.
+• If the query asks a fiqh-style or Islamic-content question even briefly, classify it as islamic.
+• Casual phrases mixed with an Islamic question are classified as islamic.
+
+Examples:
+
+casual examples:
+  hi → casual
+  salam! → casual
+  thank you so much → casual
+  good morning → casual
+  how are you doing? → casual
+  as-salamu alaykum → casual
+  jazakallah → casual
+
+non_islamic examples:
+  Who is Mark Zuckerberg? → non_islamic
+  Why is the Earth flat? → non_islamic
+  Who is Donald Trump? → non_islamic
+  What is the product of 2 and 5? → non_islamic
+  How do I invest in cryptocurrency? → non_islamic
+  Who won the World Cup? → non_islamic
+  What's the best recipe for pizza? → non_islamic
+
+islamic examples:
+  What is the meaning of Surah Al-Ikhlas? → islamic
+  Why do Shia Muslims commemorate Ashura? → islamic
+  What did Imam Ali (AS) say about justice? → islamic
+  Who was the first Imam in Shia Islam? → islamic
+  What are the main beliefs of Twelver Shia Islam? → islamic
+  What is Imamate? → islamic
+  Can I fast while traveling? → islamic
+
+Only respond with one of: islamic, non_islamic, casual. No explanation.
+"""
+
+intentClassifierUserTemplate = """Conversation so far:
+                    {chatContext}
+
+                    Current query: {query}
+
+                    Decide relevance *in context*.
+                    """
+
+def intent_classifier_messages(query: str, chatContext: str) -> list:
+    return [
+        make_cached_system_message(intentClassifierSystemTemplate),
+        HumanMessage(content=intentClassifierUserTemplate.format(
+            chatContext=chatContext,
+            query=query,
+        )),
+    ]
+
 
 # Promt templates for translation
 

--- a/core/prompt_templates.py
+++ b/core/prompt_templates.py
@@ -16,6 +16,7 @@ Voice & Personality:
 - Vary your openings; avoid starting every response with the same phrase.
 - Keep the scholarly register and precision intact — warmth and authority coexist.
 - When a question reflects curiosity or struggle, briefly affirm it before answering.
+- Do not use emojis — keep the tone warm but professional.
 
 Root answers in the teachings of the Prophet and the Ahlul Bayt.
 You may use retrieved Sunni ahadith to support your answer, while keeping the answer strictly from the Twelver Shia perspective.

--- a/modules/classification/classifier.py
+++ b/modules/classification/classifier.py
@@ -79,3 +79,29 @@ async def aclassify_non_islamic_query(query: str, session_id: str = None) -> boo
     messages = prompt_templates.nonislamic_classifier_messages(query=query, chatContext=chatContext)
     response = await _aclassify_non_islamic_query_call(messages)
     return "true" in response.content.strip().lower()
+
+
+@anthropic_retry
+async def _aclassify_intent_call(messages):
+    chat_model = chat_models.get_classifier_model()
+    return await chat_model.ainvoke(messages)
+
+
+async def aclassify_intent(query: str, session_id: str = None) -> str:
+    """3-label intent classifier for the agentic path.
+
+    Returns one of: 'islamic', 'non_islamic', 'casual'.
+    Does NOT replace the bool aclassify_non_islamic_query (still used by core/pipeline.py).
+    Uses recent conversation context if session_id is provided.
+    """
+    chatContext = ""
+    if session_id:
+        chatContext = context.get_recent_context(session_id)
+
+    messages = prompt_templates.intent_classifier_messages(query=query, chatContext=chatContext)
+    response = await _aclassify_intent_call(messages)
+    label = response.content.strip().lower()
+    if label in ("islamic", "non_islamic", "casual"):
+        return label
+    # Fallback: if LLM returns unexpected output, treat as islamic to avoid over-refusal
+    return "islamic"

--- a/tests/test_dee12_personality.py
+++ b/tests/test_dee12_personality.py
@@ -154,7 +154,7 @@ class TestCheckEarlyExitNode:
         agent = self._make_agent()
         state = self._make_state(user_query="hi", is_casual=True)
         mock_model = self._mock_llm_returning("Welcome!")
-        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+        with patch("core.chat_models.get_classifier_model", return_value=mock_model):
             result = await agent._check_early_exit_node(state)
         assert result["final_response"] == "Welcome!"
         assert result["early_exit_message"] == "Welcome!"
@@ -168,7 +168,7 @@ class TestCheckEarlyExitNode:
         state = self._make_state(user_query="salam", is_casual=True)
         mock_model = MagicMock()
         mock_model.ainvoke = AsyncMock(side_effect=Exception("timeout"))
-        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+        with patch("core.chat_models.get_classifier_model", return_value=mock_model):
             result = await agent._check_early_exit_node(state)
         assert result["final_response"] == EARLY_EXIT_CASUAL
         assert result["early_exit_message"] == EARLY_EXIT_CASUAL
@@ -178,7 +178,7 @@ class TestCheckEarlyExitNode:
         agent = self._make_agent()
         state = self._make_state(user_query="who won the World Cup?", is_non_islamic=True)
         mock_model = self._mock_llm_returning("I focus on Islamic topics, feel free to ask!")
-        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+        with patch("core.chat_models.get_classifier_model", return_value=mock_model):
             result = await agent._check_early_exit_node(state)
         assert result["final_response"] == "I focus on Islamic topics, feel free to ask!"
         assert result["early_exit_message"] == "I focus on Islamic topics, feel free to ask!"
@@ -192,7 +192,7 @@ class TestCheckEarlyExitNode:
         state = self._make_state(user_query="recipe for pizza?", is_non_islamic=True)
         mock_model = MagicMock()
         mock_model.ainvoke = AsyncMock(side_effect=Exception("network error"))
-        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+        with patch("core.chat_models.get_classifier_model", return_value=mock_model):
             result = await agent._check_early_exit_node(state)
         assert result["final_response"] == EARLY_EXIT_NON_ISLAMIC
         assert result["early_exit_message"] == EARLY_EXIT_NON_ISLAMIC
@@ -203,7 +203,7 @@ class TestCheckEarlyExitNode:
         agent = self._make_agent()
         state = self._make_state(user_query="hi", is_casual=True, is_non_islamic=True)
         mock_model = self._mock_llm_returning("Casual reply!")
-        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+        with patch("core.chat_models.get_classifier_model", return_value=mock_model):
             result = await agent._check_early_exit_node(state)
         # The casual branch should have triggered (LLM was called once for casual)
         assert mock_model.ainvoke.call_count == 1

--- a/tests/test_dee12_personality.py
+++ b/tests/test_dee12_personality.py
@@ -1,0 +1,342 @@
+"""
+DEE-12 personality + intent routing tests.
+
+Deterministic unit tests mock the LLM; opt-in real_llm tests require live
+Anthropic + Supabase + Pinecone (run with: pytest -m real_llm tests/test_dee12_personality.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import os
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Deterministic unit tests — no network, no live LLM
+# ---------------------------------------------------------------------------
+
+
+class TestIntentClassifier:
+    """aclassify_intent returns correct labels based on mocked LLM output."""
+
+    @pytest.mark.asyncio
+    async def test_aclassify_intent_casual(self):
+        from modules.classification.classifier import aclassify_intent
+
+        mock_response = MagicMock()
+        mock_response.content = "casual"
+        with patch(
+            "modules.classification.classifier._aclassify_intent_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await aclassify_intent("hi", None)
+        assert result == "casual"
+
+    @pytest.mark.asyncio
+    async def test_aclassify_intent_non_islamic(self):
+        from modules.classification.classifier import aclassify_intent
+
+        mock_response = MagicMock()
+        mock_response.content = "non_islamic"
+        with patch(
+            "modules.classification.classifier._aclassify_intent_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await aclassify_intent("who won the World Cup?", None)
+        assert result == "non_islamic"
+
+    @pytest.mark.asyncio
+    async def test_aclassify_intent_islamic(self):
+        from modules.classification.classifier import aclassify_intent
+
+        mock_response = MagicMock()
+        mock_response.content = "islamic"
+        with patch(
+            "modules.classification.classifier._aclassify_intent_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await aclassify_intent("what is Imamate?", None)
+        assert result == "islamic"
+
+    @pytest.mark.asyncio
+    async def test_aclassify_intent_unexpected_fallback(self):
+        """Unexpected LLM output must fall back to 'islamic' (safe, avoids over-refusal)."""
+        from modules.classification.classifier import aclassify_intent
+
+        mock_response = MagicMock()
+        mock_response.content = "garbage_value_not_a_valid_label"
+        with patch(
+            "modules.classification.classifier._aclassify_intent_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await aclassify_intent("something", None)
+        assert result == "islamic"
+
+    @pytest.mark.asyncio
+    async def test_aclassify_intent_strips_whitespace(self):
+        """LLM response with leading/trailing whitespace is normalised."""
+        from modules.classification.classifier import aclassify_intent
+
+        mock_response = MagicMock()
+        mock_response.content = "  CASUAL  "  # uppercase + whitespace
+        with patch(
+            "modules.classification.classifier._aclassify_intent_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await aclassify_intent("salam", None)
+        assert result == "casual"
+
+
+class TestShouldContinueRouting:
+    """_should_continue must route casual and non-Islamic states to 'exit'."""
+
+    def _make_agent(self):
+        from agents.core.chat_agent import ChatAgent
+        from agents.config.agent_config import DEFAULT_AGENT_CONFIG
+        return ChatAgent(DEFAULT_AGENT_CONFIG)
+
+    def _make_state(self, user_query="test", **overrides):
+        from agents.state.chat_state import create_initial_state
+        state = create_initial_state(user_query, "test-session-routing")
+        state.update(overrides)
+        return state
+
+    def test_should_continue_routes_casual_to_exit(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="hi", is_casual=True)
+        result = agent._should_continue(state)
+        assert result == "exit", f"Expected 'exit' for casual state, got '{result}'"
+
+    def test_should_continue_routes_non_islamic_to_exit(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="who won the World Cup?", is_non_islamic=True)
+        result = agent._should_continue(state)
+        assert result == "exit", f"Expected 'exit' for non-Islamic state, got '{result}'"
+
+    def test_should_continue_routes_fiqh_to_exit(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="can I fast while traveling?", is_fiqh=True)
+        result = agent._should_continue(state)
+        assert result == "exit", f"Expected 'exit' for fiqh state, got '{result}'"
+
+
+class TestCheckEarlyExitNode:
+    """_check_early_exit_node branches: casual, non-Islamic, UNETHICAL."""
+
+    def _make_agent(self):
+        from agents.core.chat_agent import ChatAgent
+        from agents.config.agent_config import DEFAULT_AGENT_CONFIG
+        return ChatAgent(DEFAULT_AGENT_CONFIG)
+
+    def _make_state(self, user_query="test", **overrides):
+        from agents.state.chat_state import create_initial_state
+        state = create_initial_state(user_query, "test-session-exit")
+        state.update(overrides)
+        return state
+
+    def _mock_llm_returning(self, text: str):
+        """Patch get_classifier_model to return a model whose ainvoke returns text."""
+        mock_model = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = text
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+        return mock_model
+
+    @pytest.mark.asyncio
+    async def test_check_early_exit_casual(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="hi", is_casual=True)
+        mock_model = self._mock_llm_returning("Welcome!")
+        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+            result = await agent._check_early_exit_node(state)
+        assert result["final_response"] == "Welcome!"
+        assert result["early_exit_message"] == "Welcome!"
+
+    @pytest.mark.asyncio
+    async def test_check_early_exit_casual_fallback(self):
+        """LLM raises → fallback to EARLY_EXIT_CASUAL constant."""
+        from agents.prompts.agent_prompts import EARLY_EXIT_CASUAL
+
+        agent = self._make_agent()
+        state = self._make_state(user_query="salam", is_casual=True)
+        mock_model = MagicMock()
+        mock_model.ainvoke = AsyncMock(side_effect=Exception("timeout"))
+        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+            result = await agent._check_early_exit_node(state)
+        assert result["final_response"] == EARLY_EXIT_CASUAL
+        assert result["early_exit_message"] == EARLY_EXIT_CASUAL
+
+    @pytest.mark.asyncio
+    async def test_check_early_exit_non_islamic(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="who won the World Cup?", is_non_islamic=True)
+        mock_model = self._mock_llm_returning("I focus on Islamic topics, feel free to ask!")
+        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+            result = await agent._check_early_exit_node(state)
+        assert result["final_response"] == "I focus on Islamic topics, feel free to ask!"
+        assert result["early_exit_message"] == "I focus on Islamic topics, feel free to ask!"
+
+    @pytest.mark.asyncio
+    async def test_check_early_exit_non_islamic_fallback(self):
+        """LLM raises → fallback to EARLY_EXIT_NON_ISLAMIC constant."""
+        from agents.prompts.agent_prompts import EARLY_EXIT_NON_ISLAMIC
+
+        agent = self._make_agent()
+        state = self._make_state(user_query="recipe for pizza?", is_non_islamic=True)
+        mock_model = MagicMock()
+        mock_model.ainvoke = AsyncMock(side_effect=Exception("network error"))
+        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+            result = await agent._check_early_exit_node(state)
+        assert result["final_response"] == EARLY_EXIT_NON_ISLAMIC
+        assert result["early_exit_message"] == EARLY_EXIT_NON_ISLAMIC
+
+    @pytest.mark.asyncio
+    async def test_casual_branch_precedes_non_islamic(self):
+        """When both is_casual and is_non_islamic are True, casual branch fires first."""
+        agent = self._make_agent()
+        state = self._make_state(user_query="hi", is_casual=True, is_non_islamic=True)
+        mock_model = self._mock_llm_returning("Casual reply!")
+        with patch("agents.core.chat_agent.get_classifier_model", return_value=mock_model):
+            result = await agent._check_early_exit_node(state)
+        # The casual branch should have triggered (LLM was called once for casual)
+        assert mock_model.ainvoke.call_count == 1
+        # Verify the prompt contains "casual or social message" (casual branch prompt)
+        call_args = mock_model.ainvoke.call_args[0][0]
+        assert any("casual" in str(msg.content).lower() for msg in call_args)
+
+
+class TestInitialState:
+    """create_initial_state includes is_casual field."""
+
+    def test_is_casual_in_initial_state(self):
+        from agents.state.chat_state import create_initial_state
+        state = create_initial_state("hi", "session-1")
+        assert "is_casual" in state, "is_casual missing from initial state"
+        assert state["is_casual"] is None
+
+    def test_is_casual_default_none(self):
+        from agents.state.chat_state import create_initial_state
+        state = create_initial_state("what is Imamate?", "session-2")
+        assert state["is_casual"] is None
+
+
+class TestPromptTemplates:
+    """Prompt template static checks."""
+
+    def test_intent_classifier_system_template_has_all_labels(self):
+        from core.prompt_templates import intentClassifierSystemTemplate
+        assert "casual" in intentClassifierSystemTemplate.lower()
+        assert "non_islamic" in intentClassifierSystemTemplate.lower()
+        assert "islamic" in intentClassifierSystemTemplate.lower()
+
+    def test_intent_classifier_system_template_has_examples(self):
+        from core.prompt_templates import intentClassifierSystemTemplate
+        # Must include example labels for all three classes
+        assert "→ casual" in intentClassifierSystemTemplate
+        assert "→ non_islamic" in intentClassifierSystemTemplate
+        assert "→ islamic" in intentClassifierSystemTemplate
+
+    def test_generator_system_template_has_voice_section(self):
+        from core.prompt_templates import generatorSystemTemplate
+        assert "Voice" in generatorSystemTemplate or "voice" in generatorSystemTemplate.lower()
+
+    def test_agent_system_prompt_has_voice_section(self):
+        from agents.prompts.agent_prompts import AGENT_SYSTEM_PROMPT
+        assert "Voice" in AGENT_SYSTEM_PROMPT
+
+    def test_early_exit_casual_importable(self):
+        from agents.prompts.agent_prompts import EARLY_EXIT_CASUAL, EARLY_EXIT_NON_ISLAMIC
+        assert EARLY_EXIT_CASUAL
+        assert EARLY_EXIT_NON_ISLAMIC
+        # Both must be non-empty strings
+        assert len(EARLY_EXIT_CASUAL) > 10
+        assert len(EARLY_EXIT_NON_ISLAMIC) > 10
+
+    def test_bool_classifiers_still_exist(self):
+        """Legacy bool classifiers must still be importable and callable."""
+        from modules.classification.classifier import (
+            aclassify_non_islamic_query,
+            classify_non_islamic_query,
+        )
+        import inspect
+        assert inspect.iscoroutinefunction(aclassify_non_islamic_query)
+        assert callable(classify_non_islamic_query)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in real_llm tests — require live Anthropic + Pinecone + Supabase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.real_llm
+class TestRealLLMPersonality:
+    """Live end-to-end tests for DEE-12 personality routing.
+
+    Run with: pytest -m real_llm tests/test_dee12_personality.py
+    Requires ANTHROPIC_API_KEY and other env vars to be set.
+    """
+
+    def _make_agent(self):
+        from agents.core.chat_agent import ChatAgent
+        from agents.config.agent_config import DEFAULT_AGENT_CONFIG
+        return ChatAgent(DEFAULT_AGENT_CONFIG)
+
+    @pytest.mark.asyncio
+    async def test_real_non_islamic_declined(self):
+        """Non-Islamic query must be declined, not answered."""
+        import uuid
+        agent = self._make_agent()
+        result = await agent.ainvoke(
+            user_query="who won the World Cup in 2022?",
+            session_id=f"dee12-test-{uuid.uuid4().hex}",
+        )
+        # Must have an early_exit_message (the decline message)
+        assert result.get("early_exit_message") is not None
+        # The response must NOT answer the World Cup question
+        response_text = (result.get("early_exit_message") or "").lower()
+        assert "won" not in response_text or "argentina" not in response_text, (
+            "Response appears to have answered the off-topic question"
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_casual_warm_reply(self):
+        """Casual greeting must receive a warm non-empty reply, not a retrieval error."""
+        import uuid
+        agent = self._make_agent()
+        result = await agent.ainvoke(
+            user_query="salam!",
+            session_id=f"dee12-test-{uuid.uuid4().hex}",
+        )
+        early_exit = result.get("early_exit_message") or ""
+        assert len(early_exit) > 10, (
+            f"Casual reply too short or missing: '{early_exit}'"
+        )
+        # Must not be a retrieval failure / error message
+        error_phrases = ["error", "failed", "unable to retrieve", "retrieval"]
+        assert not any(p in early_exit.lower() for p in error_phrases), (
+            f"Casual reply looks like an error: '{early_exit}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_islamic_question_works(self):
+        """Islamic question must produce a substantive answer via normal retrieval path."""
+        import uuid
+        agent = self._make_agent()
+        result = await agent.ainvoke(
+            user_query="What is the concept of Imamate in Twelver Shia Islam?",
+            session_id=f"dee12-test-{uuid.uuid4().hex}",
+        )
+        final = result.get("final_response") or ""
+        assert len(final) > 50, (
+            f"Islamic question produced a too-short or empty answer: '{final}'"
+        )
+        # Must not be an early-exit refusal for Islamic content
+        assert result.get("is_non_islamic") is not True
+        assert result.get("is_casual") is not True

--- a/tests/test_dee12_personality.py
+++ b/tests/test_dee12_personality.py
@@ -127,6 +127,94 @@ class TestShouldContinueRouting:
         assert result == "exit", f"Expected 'exit' for fiqh state, got '{result}'"
 
 
+class TestClassificationNodeIntent:
+    """DEE-12: _fiqh_classification_node runs deterministic intent classification first,
+    and _route_after_fiqh_check exits early for casual / non-Islamic intent — so casual
+    routing no longer depends on the agent's discretionary tool calls."""
+
+    def _make_agent(self):
+        from agents.core.chat_agent import ChatAgent
+        from agents.config.agent_config import DEFAULT_AGENT_CONFIG
+        return ChatAgent(DEFAULT_AGENT_CONFIG)
+
+    def _make_state(self, user_query="test", **overrides):
+        from agents.state.chat_state import create_initial_state
+        state = create_initial_state(user_query, "test-session-intent")
+        state.update(overrides)
+        return state
+
+    @pytest.mark.asyncio
+    async def test_node_casual_sets_flag_and_skips_fiqh(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="salam!")
+        with patch("modules.classification.classifier.aclassify_intent",
+                   new_callable=AsyncMock, return_value="casual"), \
+             patch("modules.fiqh.classifier.aclassify_fiqh_query",
+                   new_callable=AsyncMock, return_value="VALID_SMALL") as m_fiqh:
+            result = await agent._fiqh_classification_node(state)
+        assert result["is_casual"] is True
+        assert result["is_non_islamic"] is False
+        assert result["is_fiqh"] is False
+        m_fiqh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_node_non_islamic_sets_flag_and_skips_fiqh(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="who won the World Cup?")
+        with patch("modules.classification.classifier.aclassify_intent",
+                   new_callable=AsyncMock, return_value="non_islamic"), \
+             patch("modules.fiqh.classifier.aclassify_fiqh_query",
+                   new_callable=AsyncMock, return_value="VALID_SMALL") as m_fiqh:
+            result = await agent._fiqh_classification_node(state)
+        assert result["is_non_islamic"] is True
+        assert result["is_casual"] is False
+        m_fiqh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_node_islamic_runs_fiqh(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="can I fast while traveling?")
+        with patch("modules.classification.classifier.aclassify_intent",
+                   new_callable=AsyncMock, return_value="islamic"), \
+             patch("modules.fiqh.classifier.aclassify_fiqh_query",
+                   new_callable=AsyncMock, return_value="VALID_SMALL") as m_fiqh:
+            result = await agent._fiqh_classification_node(state)
+        assert result["is_casual"] is False
+        assert result["is_non_islamic"] is False
+        assert result["is_fiqh"] is True
+        m_fiqh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_node_intent_error_defaults_safe(self):
+        agent = self._make_agent()
+        state = self._make_state(user_query="something")
+        with patch("modules.classification.classifier.aclassify_intent",
+                   new_callable=AsyncMock, side_effect=Exception("boom")), \
+             patch("modules.fiqh.classifier.aclassify_fiqh_query",
+                   new_callable=AsyncMock, return_value="OUT_OF_SCOPE_FIQH"):
+            result = await agent._fiqh_classification_node(state)
+        assert result["is_casual"] is False
+        assert result["is_non_islamic"] is False
+
+    def test_route_casual_exits(self):
+        agent = self._make_agent()
+        assert agent._route_after_fiqh_check(self._make_state(is_casual=True, fiqh_category="")) == "exit"
+
+    def test_route_non_islamic_exits(self):
+        agent = self._make_agent()
+        assert agent._route_after_fiqh_check(self._make_state(is_non_islamic=True, fiqh_category="")) == "exit"
+
+    def test_route_islamic_continues(self):
+        agent = self._make_agent()
+        state = self._make_state(is_casual=False, is_non_islamic=False, fiqh_category="OUT_OF_SCOPE_FIQH")
+        assert agent._route_after_fiqh_check(state) == "continue"
+
+    def test_route_fiqh_goes_to_fiqh(self):
+        agent = self._make_agent()
+        state = self._make_state(is_casual=False, is_non_islamic=False, fiqh_category="VALID_SMALL")
+        assert agent._route_after_fiqh_check(state) == "fiqh"
+
+
 class TestCheckEarlyExitNode:
     """_check_early_exit_node branches: casual, non-Islamic, UNETHICAL."""
 


### PR DESCRIPTION
Closes DEE-12.

The chatbot had been coming across pretty robotic, and its "I can't answer that" responses were fixed strings that read identically every time. This warms up the voice and makes the refusal + greeting paths feel human instead of templated.

## What changed

**1. Warmer answer voice.** Added a short "Voice & Personality" section to the answer prompt (`generatorSystemTemplate`) — friendlier and more encouraging, less stiff. It's purely additive: every existing rule stays intact (Twelver Shia framing, citation requirements, no fatwas, no fabricating sources). I added the same note to `AGENT_SYSTEM_PROMPT` too, so the non-streaming `/chat/agentic` path gets the tone as well, not just the streaming one.

**2. Dynamic non-Islamic refusals.** Off-topic questions no longer return the same hardcoded "I am not allowed to answer that question…" line. They now get a short, LLM-generated decline that varies and sounds natural. I reused the pattern already in place for the UNETHICAL fiqh path rather than inventing a new one, and the old constant is still the fallback if the LLM call fails.

**3. Casual messages.** Greetings and small talk ("salam!", "thanks!") used to fall through to retrieval and come back with a cold "I couldn't retrieve enough information…". Now they get a brief, friendly reply. To make that reliable I moved intent classification (islamic / non_islamic / casual) into the mandatory classification node instead of leaving it up to the agent to decide whether to call the classifier tool — greetings weren't being caught consistently otherwise. Bonus: non-Islamic detection is now deterministic too.

## Impacted endpoints
- `POST /chat/stream/agentic` (primary) — warmer tone + dynamic decline + casual replies
- `POST /chat/agentic` (non-streaming) — same tone via `AGENT_SYSTEM_PROMPT`

No request/response shape changes.

## Migrations / env vars
None on both counts.

## Trade-off worth flagging
Deterministic routing means every Islamic query now does one extra small (Haiku) classifier call up front. I think that's a fair price for greetings and refusals actually working reliably, but flagging it in case we later want to fold the intent and fiqh classifiers into a single call.

## Testing
New suite in `tests/test_dee12_personality.py`:
- 29 deterministic unit tests (mocked, no live calls) — intent classifier, all three early-exit branches + their fallbacks, and the routing logic.
- 3 opt-in `real_llm` tests (skipped by default) — a non-Islamic query declines, a greeting gets a warm reply, and a normal question still answers with sources.

Ran in Docker (Python 3.11, matching prod):
- `pytest tests/test_dee12_personality.py` → **29 passed**
- `pytest … -m real_llm` → **3 passed**

The remaining full-suite failures are pre-existing and unrelated to this change — they're either in modules this PR doesn't touch (primer service) or older tests that patch the pre-async sync APIs and run against a fake agent, so the code changed here never executes in them. The one failure that does touch routing (`test_out_of_scope_routes_to_exit`) is a pre-existing test/code mismatch: it asserts `OUT_OF_SCOPE_FIQH` routes to `exit`, but the routing code returns `continue` for that category both before and after this PR.

Smoke-tested the three paths by hand against the streaming pipeline in Docker:
- "What did Imam Ali say about patience?" → warmer, natural tone but still fully sourced, with follow-up suggestions.
- "salam!" → "Wa alaykum assalam! …" — a friendly greeting that invites an Islamic question, instead of the old "couldn't retrieve information" response.
- "who won the World Cup?" → a natural, friendly decline that redirects to Islamic topics.