### PR TITLE
DEE-67: reference-lookup selected-language translations (Postgres sidecar + offline batch MT)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -95,7 +95,7 @@ None.
 | 260629-ia2 | Fix DEE-55 Ask Deen over-refusal on short meaningful selected text | 2026-06-29 | 14b6480 | Complete | [260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor](./quick/260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor/) |
 | 260701-j8v | Improve chatbot personality: warmer voice, dynamic non-Islamic refusal, casual-message handling (DEE-12) | 2026-07-01 | 3c376a5 | Verified | [260701-j8v-improve-chatbot-personality-warmer-answe](./quick/260701-j8v-improve-chatbot-personality-warmer-answe/) |
 | 260707-hyu | DEE-68 multilingual chatbot response quality — fix non-streaming path to honor target_language + deterministic language-injection tests + opt-in real_llm 6-language eval harness | 2026-07-07 | 3e65bc9 | Verified | [260707-hyu-dee-68-multilingual-chatbot-response-qua](./quick/260707-hyu-dee-68-multilingual-chatbot-response-qua/) |
-| 260707-pxt | DEE-67 reference-lookup selected-language translations — Postgres sidecar table + join-after-retrieval enrichment (/references + SSE) + offline build-not-run batch MT job (personal key / Sonnet 5) | 2026-07-08 | cfc65d7 | Needs Review | [260707-pxt-dee-67-reference-lookup-selected-languag](./quick/260707-pxt-dee-67-reference-lookup-selected-languag/) |
+| 260707-pxt | DEE-67 reference-lookup selected-language translations — Postgres sidecar table + join-after-retrieval enrichment (/references + SSE) + offline build-not-run batch MT job (personal key / Sonnet 5) | 2026-07-08 | cfc65d7 | Verified (migration pending live apply) | [260707-pxt-dee-67-reference-lookup-selected-languag](./quick/260707-pxt-dee-67-reference-lookup-selected-languag/) |
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-05-04 after v1.4 milestone archived)
 Milestone v1.4 complete — all 3 phases, 9 plans shipped.
 Next: `/gsd-new-milestone` to define v1.5 requirements and roadmap.
 Status: v1.4 milestone complete — OBS-02 human action required after next deploy
-Last activity: 2026-07-07 — Completed quick task 260707-hyu: DEE-68 multilingual chatbot response quality (non-streaming target_language fix + language-injection tests + opt-in real_llm 6-language eval harness)
+Last activity: 2026-07-08 — Completed quick task 260707-pxt: DEE-67 reference-lookup selected-language translations (Postgres sidecar + join-after-retrieval + offline build-not-run batch MT job); needs Docker verification (deterministic tests + alembic upgrade head)
 
 Progress bar: `▓▓▓▓▓▓░░░░` 67% (2/3 phases complete)
 
@@ -95,6 +95,7 @@ None.
 | 260629-ia2 | Fix DEE-55 Ask Deen over-refusal on short meaningful selected text | 2026-06-29 | 14b6480 | Complete | [260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor](./quick/260629-ia2-fix-dee-55-ask-deen-over-refusal-on-shor/) |
 | 260701-j8v | Improve chatbot personality: warmer voice, dynamic non-Islamic refusal, casual-message handling (DEE-12) | 2026-07-01 | 3c376a5 | Verified | [260701-j8v-improve-chatbot-personality-warmer-answe](./quick/260701-j8v-improve-chatbot-personality-warmer-answe/) |
 | 260707-hyu | DEE-68 multilingual chatbot response quality — fix non-streaming path to honor target_language + deterministic language-injection tests + opt-in real_llm 6-language eval harness | 2026-07-07 | 3e65bc9 | Verified | [260707-hyu-dee-68-multilingual-chatbot-response-qua](./quick/260707-hyu-dee-68-multilingual-chatbot-response-qua/) |
+| 260707-pxt | DEE-67 reference-lookup selected-language translations — Postgres sidecar table + join-after-retrieval enrichment (/references + SSE) + offline build-not-run batch MT job (personal key / Sonnet 5) | 2026-07-08 | cfc65d7 | Needs Review | [260707-pxt-dee-67-reference-lookup-selected-languag](./quick/260707-pxt-dee-67-reference-lookup-selected-languag/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-CONTEXT.md
+++ b/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-CONTEXT.md
@@ -1,0 +1,92 @@
+# Quick Task 260707-pxt: DEE-67 reference-lookup selected-language translations - Context
+
+**Gathered:** 2026-07-08
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+DEE-67 (sub-issue of DEE-63). Extend reference lookup so each reference includes a
+translation in the user's selected language, **alongside** the existing English and Arabic.
+Translations live in a new Postgres sidecar table keyed on the reference IDs already present
+in Pinecone metadata, joined in AFTER retrieval so the vector/retrieval path is untouched.
+Affected surfaces: `POST /references` (`api/reference.py` → `core/pipeline.references_pipeline`)
+and the `hadith_references` / `quran_references` SSE events (formatted in `core/utils.py`:
+`format_references_as_json` @227, `format_quran_references_as_json` @268).
+
+Storage decision is already SETTLED on the Linear ticket (Postgres sidecar, NOT Pinecone
+metadata — 40 KB/vector limit). Review workflow is SETTLED per mentor: MT ships, team
+sample-reviews in dev before go-live, environment-level gate, lightweight provenance columns.
+See memory `dee63-translation-review-workflow`.
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### MT engine (LOCKED)
+- Use a **dedicated/personal Claude API key on Sonnet 5 (`claude-sonnet-5`)** for the batch
+  translation job — **NOT** the app's environment `ANTHROPIC_API_KEY`.
+- The batch script must read its own credential from a **new, dedicated env var** (e.g.
+  `TRANSLATION_ANTHROPIC_API_KEY`) and a configurable model (default `claude-sonnet-5`), so
+  translation cost/usage stays isolated on the user's personal key and never touches the
+  running app's key or `core.chat_models` app model.
+- Document that the user sets `TRANSLATION_ANTHROPIC_API_KEY` before running the job.
+
+### Batch MT scope (LOCKED)
+- Build the machinery to translate the **ENTIRE reference corpus × 6 languages**, but **DO
+  NOT run it** as part of this task. Deliver a re-runnable script + exact start-to-finish
+  commands (in the README/CLAUDE.md commands block and the SUMMARY).
+- Because the corpus won't be populated in this task, at request time most references will
+  have no translation yet → the EN/AR fallback covers them. Full population is a separate
+  offline ops run the user triggers later.
+- Deterministic tests MUST mock translation — do not call the live MT API in tests.
+
+### Fields to translate (LOCKED)
+- Translate **hadith English text (`page_content_en` / `text`)**, **Quran translation
+  (`quran_translation`)**, and **tafsir text (`tafsir_text` / tafsir `page_content_en`)**.
+- The sidecar schema must therefore handle multiple reference types with different id schemes:
+  hadith uses `hadith_id`; Quran/tafsir docs have no single obvious id (metadata has
+  surah_name/chapter_number/verses_covered/author/collection/volume). **Planner/executor to
+  design a stable key for Quran/tafsir** (e.g. a composite natural key or a synthesized
+  deterministic id) — flag this explicitly in the plan.
+
+### Review column (LOCKED)
+- Columns: `source` (= `mt`), `translated_at`, `model` (translation model/version), and a
+  **nullable `reviewed_at`** timestamp (spot-mark hedge). NOT a full per-row status/reviewer
+  state machine.
+
+### Claude's Discretion
+- Exact table shape (single unified `reference_translations` table with a `ref_type`
+  discriminator + `ref_key` + `language`, vs per-type tables) — planner decides, favoring the
+  simplest design that cleanly handles both hadith and Quran/tafsir keys.
+- How the batch job **enumerates the full corpus**: iterating the Pinecone indices (list/fetch
+  by id) vs translating from an original source dataset if one exists in the repo — planner to
+  determine the most reliable enumeration source.
+- How `language` is supplied to `POST /references`: add a `language` query param mirroring the
+  existing `sect`/`limit` params (`ReferenceRequest` currently only has `user_query`). The SSE
+  chat path already carries `target_language` in `ChatState` — thread it into the format
+  functions there.
+- Alembic migration authored but coordinate the standard `alembic upgrade head` step.
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Join-after-retrieval: keep `retriever` / Pinecone untouched; enrich the formatted reference
+  dicts in `core/utils.py` (or a thin service the format functions call) with a keyed Postgres
+  lookup of `(ref_key, language)` → translated text, added alongside `text` / `text_ar`.
+- New response field naming: e.g. `text_translated` + `translated_language`, so the frontend
+  gets EN + AR + selected-language without breaking the existing `text`/`text_ar` contract.
+- Batch script lives under `scripts/` (mirrors `scripts/ingest_fiqh.py`); expose a
+  `--languages`, `--limit`/`--dry-run`, and `--ref-type` style CLI so a small sample OR the
+  full run is possible from the same entrypoint.
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- Linear DEE-67 (storage + review decisions, success criteria).
+- Memory `dee63-translation-review-workflow` (mentor's MT-ships / sample-review-in-dev call).
+- Existing pattern: `scripts/ingest_fiqh.py` (batch corpus job), `db/models/*` + `alembic/versions/*`
+  (model + migration pattern), `core/utils.py` format functions, `core/pipeline.references_pipeline`.
+</canonical_refs>

--- a/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-PLAN.md
+++ b/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-PLAN.md
@@ -1,0 +1,325 @@
+---
+phase: 260707-pxt
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - db/models/reference_translations.py
+  - alembic/versions/20260707_create_reference_translations_table.py
+  - services/reference_translation_service.py
+  - core/utils.py
+  - core/pipeline.py
+  - api/reference.py
+  - core/pipeline_langgraph.py
+  - tests/test_reference_translations.py
+  - scripts/translate_references.py
+  - tests/test_translate_references.py
+  - CLAUDE.md
+autonomous: true
+requirements:
+  - DEE-67
+must_haves:
+  truths:
+    - "POST /references?language=<lang> returns each hadith reference with its existing text/text_ar fields unchanged, plus a new text_translated field populated from the reference_translations table when a row exists for that hadith_id+language, and null when it doesn't (fallback to EN/AR, per LOCKED decision)"
+    - "The SSE hadith_references and quran_references events on POST /chat/stream/agentic carry the same selected-language translation fields, threaded from ChatState's existing target_language -- no new request field required"
+    - "Pinecone retrieval/vector search is completely untouched -- translations are joined in AFTER retrieval, only inside the formatter layer (core/utils.py) via a Postgres sidecar lookup"
+    - "A re-runnable scripts/translate_references.py exists that, given TRANSLATION_ANTHROPIC_API_KEY, can translate the entire hadith + quran_translation + tafsir_text corpus across all 6 languages into the reference_translations table -- but this task does NOT execute it against the full corpus or any live service"
+    - "Because the corpus is not populated during this task, at request time most references have no matching row yet, so text_translated/quran_translation_translated/tafsir_text_translated come back null and the client falls back to the existing EN/AR fields"
+    - "alembic heads resolves to a single head after this migration, chaining cleanly onto the current head (onboarding_profiles_001)"
+  artifacts:
+    - path: "db/models/reference_translations.py"
+      provides: "ReferenceTranslation SQLAlchemy model: composite PK (ref_type, ref_key, language) + translated_text + provenance columns (source, translated_at, model, nullable reviewed_at)"
+    - path: "alembic/versions/20260707_create_reference_translations_table.py"
+      provides: "Migration creating reference_translations, revision reference_translations_001, down_revision onboarding_profiles_001"
+    - path: "services/reference_translation_service.py"
+      provides: "alookup_translations(ref_type, ref_keys, language) -> dict[str, str], self-contained async DB lookup usable from both FastAPI routes and non-route async generators"
+    - path: "core/utils.py"
+      provides: "aformat_references_as_json(retrieved_docs, language) and aformat_quran_references_as_json(quran_docs, language) -- async wrappers joining MT translations onto the existing sync formatters"
+    - path: "scripts/translate_references.py"
+      provides: "Offline batch MT job using a dedicated TRANSLATION_ANTHROPIC_API_KEY + claude-sonnet-5 (never core.chat_models / app ANTHROPIC_API_KEY), enumerating the full corpus via Pinecone list()/fetch()"
+    - path: "tests/test_reference_translations.py"
+      provides: "Deterministic mocked tests for the lookup service + async formatters + language threading through core.pipeline.references_pipeline"
+    - path: "tests/test_translate_references.py"
+      provides: "Deterministic mocked tests for the batch script (CLI parsing, translate_text, dry-run safety, upsert)"
+  key_links:
+    - from: "api/reference.py"
+      to: "core/pipeline.py::references_pipeline"
+      via: "new language Query(...) param passed through, mirroring the existing sect/limit pattern"
+      pattern: "language:\\s*str\\s*=\\s*Query"
+    - from: "core/pipeline.py::references_pipeline"
+      to: "core/utils.py::aformat_references_as_json"
+      via: "await utils.aformat_references_as_json(docs, language) replacing the sync call"
+      pattern: "await utils\\.aformat_references_as_json"
+    - from: "core/pipeline_langgraph.py"
+      to: "core/utils.py::aformat_references_as_json / aformat_quran_references_as_json"
+      via: "await call passing the existing in-scope target_language before yielding hadith_references/quran_references SSE events"
+      pattern: "aformat_(references|quran_references)_as_json\\(.*target_language"
+    - from: "core/utils.py"
+      to: "services/reference_translation_service.py::alookup_translations"
+      via: "join-after-retrieval lookup keyed by hadith_id (ref_type=hadith) or Pinecone chunk_id (ref_type=quran_translation / tafsir_text)"
+      pattern: "reference_translation_service\\.alookup_translations"
+    - from: "services/reference_translation_service.py"
+      to: "db/models/reference_translations.py::ReferenceTranslation"
+      via: "SQLAlchemy async select().where(ref_type=..., ref_key.in_(...), language=...)"
+      pattern: "select\\(ReferenceTranslation\\)"
+    - from: "scripts/translate_references.py"
+      to: "db/models/reference_translations.py::ReferenceTranslation"
+      via: "sync Session.merge() upsert keyed by the same composite PK"
+      pattern: "db\\.merge\\(.*ReferenceTranslation"
+---
+
+<objective>
+Implement DEE-67: extend reference lookup so each hadith/Quran/tafsir reference can include a translation in the user's selected language, alongside the existing English (`text`/`page_content_en`/`quran_translation`/`tafsir_text`) and Arabic (`text_ar`) fields. Translations live in a new Postgres sidecar table (`reference_translations`) keyed on the reference IDs already present in Pinecone metadata (`hadith_id`) or the Pinecone vector ID itself (`chunk_id` for Quran/tafsir), joined in AFTER retrieval so the vector/retrieval path is completely untouched. Thread a `language` selector through `POST /references` and the `hadith_references`/`quran_references` SSE events. Build (but do not run) a re-runnable offline batch MT job that uses a dedicated personal Anthropic key + `claude-sonnet-5` to populate the full corpus across 6 languages later.
+
+Purpose: Users viewing reference citations currently only see EN/AR text regardless of their selected chat language. This closes that gap without touching the retrieval/ranking path, and without coupling translation cost/usage to the app's production Anthropic key.
+
+Output:
+- `reference_translations` Postgres table + SQLAlchemy model + Alembic migration
+- `services/reference_translation_service.py` async lookup service
+- `core/utils.py` async formatter wrappers wired into `/references` and the SSE `hadith_references`/`quran_references` events, with EN/AR fallback when a translation row doesn't exist yet
+- `scripts/translate_references.py` — re-runnable, not executed in this task — plus documented start-to-finish commands in `CLAUDE.md`
+- Deterministic mocked tests covering the lookup service, async formatters, language threading, and the batch script (no live network/DB calls in tests)
+</objective>
+
+<execution_context>
+@/Users/admin2/.claude/plugins/cache/gsd-plugin/gsd/4.0.2/workflows/execute-plan.md
+@/Users/admin2/.claude/plugins/cache/gsd-plugin/gsd/4.0.2/templates/summary.md
+</execution_context>
+
+<context>
+@/Users/admin2/deen-backend/.planning/STATE.md
+@/Users/admin2/deen-backend/CLAUDE.md
+@/Users/admin2/deen-backend/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-CONTEXT.md
+
+<!-- Key interfaces the executor needs -- extracted from codebase. Use directly, no exploration. -->
+<interfaces>
+From `core/utils.py` (current, unchanged sync functions to build on top of -- do NOT modify their internals):
+- `format_references_as_json(retrieved_docs: list) -> list` (~line 227): iterates `retrieved_docs`, each item is a dict with a `metadata` key (containing `hadith_id`, etc.) and `page_content_en`/`page_content_ar` keys (already decompressed by the reranker). Returns a list of dicts with keys `author, volume, book_number, book_title, chapter_number, chapter_title, collection, grade_ar, grade_en, hadith_id, hadith_no, hadith_url, lang, sect, reference, text, text_ar`. Output list preserves 1:1 order/length with `retrieved_docs`.
+- `format_quran_references_as_json(quran_docs: list) -> list` (~line 268): iterates `quran_docs` inside a single try/except wrapping the WHOLE loop (not per-item) -- on any exception the returned list may be shorter than `quran_docs`. Each output dict has keys `surah_name, title, chapter_number, verses_covered, starting_verse, ending_verse, author, collection, volume, sect, quran_translation, tafsir_text`. Does NOT include `chunk_id` in its output -- read `chunk_id` from the original `quran_docs` input instead.
+- Module currently imports only `Document`, `traceback`, `base64`, `gzip` -- no `asyncio`, no `typing`.
+
+From `modules/retrieval/retriever.py` (source of the `quran_docs` list passed to the formatter -- both `retrieve_quran_documents` and `aretrieve_quran_documents`):
+- Each Quran/tafsir doc dict has top-level keys: `chunk_id` (the Pinecone vector/match `.id` -- a stable, already-existing identifier), `metadata`, `page_content_en` (decompressed tafsir text, from raw Pinecone metadata field `text_chunk`), `quran_translation` (decompressed, from raw Pinecone metadata field `english_quran_translation`).
+- Raw hadith Pinecone metadata (see `modules/reranking/reranker.py` ~lines 68-107): `hadith_id` (plain), `text_en` (gzip+base64 compressed, decompress via `core.utils.decompress_text`), `text_ar` (same compression).
+
+From `core/pipeline.py` (current `references_pipeline`, ~lines 88-110):
+- `async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT):` -- classifies, enhances, then `asyncio.gather`s `retriever.aretrieve_shia_documents` / `aretrieve_sunni_documents`, then for each `(label, docs)` does `results[label] = utils.format_references_as_json(docs)`. Only handles hadith docs (no Quran retrieval on this path today).
+
+From `api/reference.py` (current route, ~lines 22-28):
+- `sect: str = Query("both", enum=["sunni", "shia", "both"])` and `limit: int = Query(10, ge=1, le=50, ...)` are the exact pattern to mirror for the new `language` param. Route calls `await pipeline.references_pipeline(user_query, sect, limit)`.
+
+From `core/pipeline_langgraph.py` (SSE path, ~lines 149/515-521):
+- `target_language: str = "english"` is already a parameter in scope in the generator function that emits SSE events.
+- Current code: `if hadith_docs: hadith_json = utils.format_references_as_json(hadith_docs); yield sse_event("hadith_references", {"references": hadith_json})` and the analogous block for `quran_docs` / `format_quran_references_as_json` / `quran_references`. This whole function is `async def` and already uses `await` extensively elsewhere in the same block -- safe to `await` the new async formatters here.
+
+From `db/session.py`: `Base = declarative_base()`, sync `engine`/`SessionLocal` (used by the batch script). From `db/async_session.py`: `AsyncSessionLocal = async_sessionmaker(...)` already configured with pooling -- used by the new lookup service.
+
+From `alembic/versions/` head chain: the current head is `onboarding_profiles_001` (`20260414_create_user_onboarding_profiles.py`) -- no other migration lists it as `down_revision`. Migration style to mirror (see that file): `revision = '...'`, `down_revision = '...'`, `op.create_table(...)` with `sa.Column(..., primary_key=True, nullable=False)` for composite keys, `sa.TIMESTAMP(timezone=True)` with `server_default=sa.func.now()`.
+
+From `core/config.py`: `PINECONE_API_KEY`, `DEEN_DENSE_INDEX_NAME`, `QURAN_DENSE_INDEX_NAME` already validated at import (fail-fast). `ANTHROPIC_API_KEY` is the APP key -- the batch script MUST NOT use it.
+
+From `core/chat_models.py`: shows the pattern to explicitly AVOID for the batch script (it wraps the app's `ANTHROPIC_API_KEY` via `langchain_anthropic.ChatAnthropic`). The batch script must instead use the raw `anthropic` SDK (`anthropic==0.92.0`, already in `requirements.txt`) with `TRANSLATION_ANTHROPIC_API_KEY`.
+
+From `scripts/ingest_fiqh.py` -- the batch-job shape to mirror: `argparse` CLI in `main()`, `project_root` sys.path insert, `setup_logging()` + module logger, pure/testable helper functions (not inlined in `main()`), Pinecone client init via `Pinecone(api_key=...)`.
+
+From `tests/conftest.py`: sets test-only env defaults (`ANTHROPIC_API_KEY`, `PINECONE_API_KEY`, `DEEN_*_INDEX_NAME`, `DB_USER/PASSWORD/HOST/PORT/NAME`, etc.) via `os.environ.setdefault`, so importing `db.async_session` / `db.session` / `core.config` at module level in tests never touches a real network or DB connection unless a test explicitly does so.
+
+Canonical 6-language list already established in this codebase (DEE-68, `tests/test_dee68_multilingual_generation.py`): `["arabic", "farsi", "urdu", "german", "bahasa melayu", "french"]` -- lowercase free-text strings, NOT ISO codes, matching `ChatState["target_language"]` convention. Reuse this exact list/casing for `language` everywhere in this plan (no enum validation at the Pydantic/Query layer, matching how `target_language`/`ChatRequest.language` are plain `str` today).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: reference_translations table (model + migration)</name>
+  <files>db/models/reference_translations.py, alembic/versions/20260707_create_reference_translations_table.py</files>
+  <action>
+Create `db/models/reference_translations.py` defining `ReferenceTranslation(Base)` (import `Base` from `..session`) with `__tablename__ = "reference_translations"` and these columns, matching the LOCKED schema decision exactly (no extra reviewer-state columns):
+- `ref_type` (Text, primary_key=True, nullable=False) -- one of `"hadith"`, `"quran_translation"`, `"tafsir_text"`. `quran_translation` and `tafsir_text` deliberately share the same `ref_key` (the Pinecone chunk_id) but are separate rows/ref_types, because a single Quran/tafsir chunk has two independently-translatable fields.
+- `ref_key` (Text, primary_key=True, nullable=False) -- `hadith_id` for `ref_type="hadith"`; the Pinecone vector `chunk_id` for the other two ref_types. Document this mapping in a docstring/comment on the model, since it's the resolution to the "multiple reference types with different id schemes" concern flagged in CONTEXT.md -- Quran/tafsir chunks already have a stable, existing Pinecone vector ID (`chunk_id`), so no synthesized composite key is needed.
+- `language` (Text, primary_key=True, nullable=False) -- one of the 6 canonical language strings (see `<interfaces>`), lowercase.
+- `translated_text` (Text, nullable=False)
+- `source` (Text, nullable=False, server_default="mt")
+- `translated_at` (TIMESTAMP(timezone=True), nullable=False, server_default=`func.now()`)
+- `model` (Text, nullable=False) -- the translation model/version string, e.g. `"claude-sonnet-5"`
+- `reviewed_at` (TIMESTAMP(timezone=True), nullable=True) -- spot-review hedge, no per-row status/reviewer state machine
+
+Create `alembic/versions/20260707_create_reference_translations_table.py` mirroring the style of `alembic/versions/20260414_create_user_onboarding_profiles.py`: `revision = 'reference_translations_001'`, `down_revision = 'onboarding_profiles_001'` (the current head -- verify no other migration file already declares this as its `down_revision` before writing). `upgrade()` calls `op.create_table('reference_translations', ...)` with the same 8 columns/types/defaults as the model above (composite primary key via three `primary_key=True` columns). `downgrade()` calls `op.drop_table('reference_translations')`. Do not add extra indexes -- the composite PK on `(ref_type, ref_key, language)` already covers the query pattern (`ref_type` + `ref_key IN (...)` + `language` equality) used by the lookup service in Task 2.
+
+Do NOT run `alembic upgrade head` as part of this task -- author the migration only; running it against the real database is a separate step the user performs (document the exact command in Task 3's CLAUDE.md update).
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -c "
+from db.models.reference_translations import ReferenceTranslation
+cols = {c.name for c in ReferenceTranslation.__table__.columns}
+required = {'ref_type','ref_key','language','translated_text','source','translated_at','model','reviewed_at'}
+assert required <= cols, f'missing columns: {required - cols}'
+pk = {c.name for c in ReferenceTranslation.__table__.primary_key.columns}
+assert pk == {'ref_type','ref_key','language'}, f'unexpected PK: {pk}'
+print('model OK:', sorted(cols))
+" && alembic heads
+</automated>
+  </verify>
+  <done>
+    - `db/models/reference_translations.py` defines `ReferenceTranslation` with the 8 columns above and a 3-column composite primary key
+    - `alembic/versions/20260707_create_reference_translations_table.py` exists with `down_revision = 'onboarding_profiles_001'`, and `alembic heads` resolves to exactly one head (the new migration)
+    - No existing migration file is broken or renumbered
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Join-after-retrieval translation lookup, wired into /references and SSE reference events</name>
+  <files>services/reference_translation_service.py, core/utils.py, core/pipeline.py, api/reference.py, core/pipeline_langgraph.py, tests/test_reference_translations.py</files>
+  <behavior>
+    - `alookup_translations("hadith", ["h1", "h2"], "urdu")` returns `{"h1": "...", "h2": "..."}` when matching rows exist, using a mocked/fake AsyncSession (no real DB) -- and returns `{}` (not raising) when the DB call raises, or when `ref_keys` is empty
+    - `aformat_references_as_json(docs, language=None)` and `aformat_references_as_json(docs, language="english")` both return the unmodified base list (from `format_references_as_json`) plus `text_translated=None` and `translated_language=None` on every item, WITHOUT calling `alookup_translations` at all
+    - `aformat_references_as_json(docs, language="urdu")` calls `alookup_translations("hadith", <hadith_ids>, "urdu")` exactly once and merges results onto `text_translated`; hadith_ids with no matching translation get `text_translated=None` (fallback) while `translated_language="urdu"` is still set on every item
+    - `aformat_quran_references_as_json(quran_docs, language="urdu")` calls `alookup_translations` twice (once with `ref_type="quran_translation"`, once with `ref_type="tafsir_text"`, both keyed by `chunk_id`) and merges results onto `quran_translation_translated` / `tafsir_text_translated` respectively; existing `quran_translation`/`tafsir_text` fields are unchanged
+    - `core.pipeline.references_pipeline(user_query, sect, limit, language="urdu")` passes `language` through to `utils.aformat_references_as_json`, proven via a mocked pipeline call asserting the language argument reaches the formatter
+  </behavior>
+  <action>
+Create `services/reference_translation_service.py`. Add module docstring explaining this is the join-after-retrieval lookup for DEE-67 (Postgres sidecar, not Pinecone metadata -- see CONTEXT.md). Import `AsyncSessionLocal` from `db.async_session`, `ReferenceTranslation` from `db.models.reference_translations`, `select` from `sqlalchemy`, `logging`, and `Iterable` from `typing`. Define `logger = logging.getLogger(__name__)`. Implement:
+
+`async def alookup_translations(ref_type: str, ref_keys: Iterable[str], language: str) -> dict[str, str]:` -- normalize `ref_keys` to a deduplicated list of non-empty strings (skip `None`, `""`, `"N/A"`); return `{}` immediately if the list is empty (no DB round trip for empty input). Otherwise open `async with AsyncSessionLocal() as db:`, build `stmt = select(ReferenceTranslation).where(ReferenceTranslation.ref_type == ref_type, ReferenceTranslation.ref_key.in_(keys), ReferenceTranslation.language == language)`, `result = await db.execute(stmt)`, `rows = result.scalars().all()`, return `{row.ref_key: row.translated_text for row in rows}`. Wrap the whole DB block in `try/except Exception:` -- on any exception, `logger.error(..., exc_info=True)` with `ref_type`/`language` in the message, and return `{}` so callers always get a safe, empty-dict fallback rather than a raised exception (matches the project's tool-error-dict convention in `agents/tools/`).
+
+This function has no FastAPI `Depends()` call site (it's invoked from both a route function and a plain async generator in `core/pipeline_langgraph.py`), so it must open and close its own short-lived `AsyncSessionLocal()` context manager per call -- do not try to inject a session parameter.
+
+In `core/utils.py`: add `import asyncio` and `from typing import Optional` to the top-level imports (alongside the existing `Document`, `traceback`, `base64`, `gzip`). Add a top-level `from services import reference_translation_service` import (no circular-import risk -- confirmed no `services/*.py` module imports `core.utils`). Then add two new async functions immediately after `format_quran_references_as_json` (do not modify `format_references_as_json` or `format_quran_references_as_json` themselves):
+
+`async def aformat_references_as_json(retrieved_docs: list, language: Optional[str] = None) -> list:` -- call `base = format_references_as_json(retrieved_docs)` first (reuse, don't duplicate). Normalize `normalized_language = (language or "").strip().lower()`. If `not normalized_language or normalized_language == "english"`: set `ref["text_translated"] = None` and `ref["translated_language"] = None` on every `ref` in `base`, then `return base` (no DB call). Otherwise: build `hadith_ids = [ref.get("hadith_id") for ref in base]`, call `translations = await reference_translation_service.alookup_translations("hadith", hadith_ids, normalized_language)`, then for each `ref` in `base` set `ref["text_translated"] = translations.get(str(ref.get("hadith_id")))` and `ref["translated_language"] = normalized_language`; `return base`.
+
+`async def aformat_quran_references_as_json(quran_docs: list, language: Optional[str] = None) -> list:` -- call `base = format_quran_references_as_json(quran_docs)` first. Because that sync formatter's single try/except wraps its whole loop (can return a shorter list on error -- see `<interfaces>`), build `chunk_ids = [doc.get("chunk_id") for doc in (quran_docs or [])[: len(base)]]` (defensive slice to keep alignment). Normalize language the same way. If no translation needed: set `ref["quran_translation_translated"] = None`, `ref["tafsir_text_translated"] = None`, `ref["translated_language"] = None` on every `ref` in `base`; return `base`. Otherwise: run both lookups concurrently with `asyncio.gather`: `translation_lookup, tafsir_lookup = await asyncio.gather(reference_translation_service.alookup_translations("quran_translation", chunk_ids, normalized_language), reference_translation_service.alookup_translations("tafsir_text", chunk_ids, normalized_language))`; then `for ref, chunk_id in zip(base, chunk_ids): ref["quran_translation_translated"] = translation_lookup.get(str(chunk_id)); ref["tafsir_text_translated"] = tafsir_lookup.get(str(chunk_id)); ref["translated_language"] = normalized_language`; `return base`.
+
+In `core/pipeline.py`: change `async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT):` to add a `language: str = "english"` parameter (keep it last, after `limit`, to avoid breaking positional-arg call sites -- but update `api/reference.py`'s call site below to pass it explicitly by position anyway). Replace the loop body `results[label] = utils.format_references_as_json(docs)` with `results[label] = await utils.aformat_references_as_json(docs, language)`. Do NOT touch the separate legacy sync `chat_pipeline_streaming` function (line ~43-84) -- it is out of scope for this task (not in DEE-67's affected-surfaces list).
+
+In `api/reference.py`: add `language: str = Query("english", description="Selected language for translated reference text (e.g. 'arabic', 'farsi', 'urdu', 'german', 'bahasa melayu', 'french'). Defaults to English -- no translation join performed.")` as a new parameter on `references_pipeline`, mirroring the existing `sect`/`limit` `Query(...)` pattern (no `enum=` restriction, matching the free-text convention already used for `target_language` elsewhere). Update the call `results = await pipeline.references_pipeline(user_query, sect, limit)` to `results = await pipeline.references_pipeline(user_query, sect, limit, language)`.
+
+In `core/pipeline_langgraph.py`: at the two call sites near lines 515-521, change `hadith_json = utils.format_references_as_json(hadith_docs)` to `hadith_json = await utils.aformat_references_as_json(hadith_docs, target_language)`, and `quran_json = utils.format_quran_references_as_json(quran_docs)` to `quran_json = await utils.aformat_quran_references_as_json(quran_docs, target_language)`. `target_language` is already an in-scope parameter of the enclosing function -- no new parameter threading needed here.
+
+Create `tests/test_reference_translations.py` implementing every case in `<behavior>` above, plus: a fake async-context-manager `AsyncSession` stub (with a fake `execute()` returning an object whose `.scalars().all()` returns a list of simple row objects carrying `.ref_key`/`.translated_text` attributes) patched onto `services.reference_translation_service.AsyncSessionLocal`, to test `alookup_translations` directly against realistic SQLAlchemy-shaped return values without a real database; and a test that a raised exception inside the fake session's `execute()` still returns `{}` from `alookup_translations` (no exception propagates). Use `@pytest.mark.asyncio` throughout (already a project dependency, see `pytest-asyncio==0.26.0` in `requirements.txt`). Follow the module docstring / import style of `tests/test_dee68_multilingual_generation.py` (mocked, no network).
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -m pytest tests/test_reference_translations.py -q -x 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    - `services/reference_translation_service.py::alookup_translations` exists, opens its own `AsyncSessionLocal`, and never raises (returns `{}` on error)
+    - `core/utils.py::aformat_references_as_json` and `aformat_quran_references_as_json` exist, both skip the DB call entirely when `language` is unset/`"english"`, and both preserve every existing field from the sync formatters unchanged
+    - `POST /references` accepts a `language` query param and threads it to `core.pipeline.references_pipeline` -> `utils.aformat_references_as_json`
+    - `core/pipeline_langgraph.py`'s SSE `hadith_references`/`quran_references` events are built via the new async formatters, passing the existing `target_language`
+    - `pytest tests/test_reference_translations.py -q` passes with zero network/DB calls
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Offline batch MT job (build only, do not run) + documented commands</name>
+  <files>scripts/translate_references.py, tests/test_translate_references.py, CLAUDE.md</files>
+  <behavior>
+    - `parse_args([])` (no CLI args) returns defaults: `languages == "arabic,farsi,urdu,german,bahasa melayu,french"`, `ref_type == "all"`, `dry_run is False`, `model == "claude-sonnet-5"`, `limit is None`
+    - `_get_translation_client()` raises `ValueError` (mentioning `TRANSLATION_ANTHROPIC_API_KEY`) when that env var is unset; when set, it constructs and returns an `anthropic.Anthropic` client using that key (proven via a patched `anthropic.Anthropic` class, asserting it was called with `api_key=<the env var value>`) -- never reads `ANTHROPIC_API_KEY`
+    - `translate_text(fake_client, model="claude-sonnet-5", text="...", language="urdu")` calls `fake_client.messages.create(model=..., system=<system prompt containing "urdu">, messages=[{"role": "user", "content": "..."}], max_tokens=...)` and returns the stripped text from the mocked response's `content[0].text`
+    - `run_batch(..., dry_run=True, ...)` against a fake Pinecone client/index (stubbed `.list()`/`.fetch()`) NEVER calls `translate_text` or `upsert_translation` (patched and asserted `not called`), but returns a summary dict with correct per-ref_type/per-language counts of items that WOULD be translated
+    - `run_batch(..., limit=1, dry_run=True, ...)` processes only 1 source item even when the fake index has more available IDs
+    - `upsert_translation(fake_session_factory, ref_type="hadith", ref_key="h1", language="urdu", translated_text="...", model_name="claude-sonnet-5")` constructs a `ReferenceTranslation` row with `source="mt"`, a timezone-aware `translated_at`, and the given `model`/`ref_type`/`ref_key`(as `str`)/`language`/`translated_text`, then calls `db.merge(row)` and `db.commit()` on the fake session
+  </behavior>
+  <action>
+Create `scripts/translate_references.py`, structured like `scripts/ingest_fiqh.py` (module docstring with usage examples, `project_root` sys.path insert, `setup_logging()` + module `logger`, pure/testable top-level functions -- nothing inlined in `main()`). Import `Anthropic` from `anthropic` (NOT `langchain_anthropic`, NOT `core.chat_models`). Import `Pinecone` from `pinecone`. Import `SessionLocal` from `db.session`, `ReferenceTranslation` from `db.models.reference_translations`, `decompress_text` from `core.utils`, and `PINECONE_API_KEY`, `DEEN_DENSE_INDEX_NAME`, `QURAN_DENSE_INDEX_NAME` from `core.config`. Do NOT import `ANTHROPIC_API_KEY` from `core.config` anywhere in this file -- this is the LOCKED isolation requirement.
+
+Module-level constants: `SUPPORTED_LANGUAGES = ["arabic", "farsi", "urdu", "german", "bahasa melayu", "french"]` (the exact canonical list from `<interfaces>`); `REF_TYPE_CHOICES = ["hadith", "quran_translation", "tafsir_text"]`; `DEFAULT_MODEL = "claude-sonnet-5"`; `TRANSLATION_SYSTEM_PROMPT` -- a format-string constant (with a `{language}` placeholder) instructing: faithful, literal translation into `{language}` of a Twelver Shia Islamic reference text (hadith/Quran translation/tafsir); preserve all meaning, terminology, honorifics, and the Twelver Shia theological framing; do not add interpretation, commentary, opinion, or fatwa-like guidance; do not omit or summarize; return ONLY the translated text with no preamble or explanation (this operationalizes the CLAUDE.md religious-sensitivity hard rule for this MT job).
+
+`def parse_args(argv=None) -> argparse.Namespace:` -- `--languages` (default `",".join(SUPPORTED_LANGUAGES)`, comma-separated string), `--ref-type` (choices `REF_TYPE_CHOICES + ["all"]`, default `"all"`), `--dry-run` (`action="store_true"`), `--limit` (`type=int`, `default=None`, help "cap number of source items enumerated per ref_type, for sampling"), `--model` (default `DEFAULT_MODEL`). Return `parser.parse_args(argv)`.
+
+`def _get_translation_client() -> Anthropic:` -- `api_key = os.getenv("TRANSLATION_ANTHROPIC_API_KEY")`; if falsy, `raise ValueError("TRANSLATION_ANTHROPIC_API_KEY is not set. This batch job requires a dedicated personal Claude API key, separate from the app's ANTHROPIC_API_KEY, so translation cost/usage never touches the running app's key. Set TRANSLATION_ANTHROPIC_API_KEY before running.")`; otherwise `return Anthropic(api_key=api_key)`. Only called when `not args.dry_run`, so `--dry-run` never requires this env var.
+
+`def translate_text(client, *, model: str, text: str, language: str) -> str:` -- calls `client.messages.create(model=model, max_tokens=2048, system=TRANSLATION_SYSTEM_PROMPT.format(language=language), messages=[{"role": "user", "content": text}])`, returns `response.content[0].text.strip()`.
+
+`def upsert_translation(session_factory, *, ref_type: str, ref_key: str, language: str, translated_text: str, model_name: str) -> None:` -- `from datetime import datetime, timezone`; `with session_factory() as db:` construct `row = ReferenceTranslation(ref_type=ref_type, ref_key=str(ref_key), language=language, translated_text=translated_text, source="mt", translated_at=datetime.now(timezone.utc), model=model_name)`; `db.merge(row)`; `db.commit()` (SQLAlchemy `Session.merge()` performs an insert-or-update keyed by primary key, which is exactly the upsert semantics needed here for re-runnable idempotent execution).
+
+Enumeration helpers (pure, index-agnostic so they're testable with a fake Pinecone index object exposing `.list(namespace=...)` -- a generator yielding lists of id strings -- and `.fetch(ids=..., namespace=...)` -- returning an object with a `.vectors` dict mapping id -> object with a `.metadata` dict):
+
+`def _iter_source_items(pc_index, *, namespace: str = "ns1", limit: Optional[int] = None):` -- generator yielding `(item_id, metadata_dict)` tuples by iterating `pc_index.list(namespace=namespace)` pages, calling `pc_index.fetch(ids=page_ids, namespace=namespace)` per page, and yielding from `fetched.vectors.items()` as `(vector_id, vector.metadata)`; stop (via a running counter) once `limit` items have been yielded, if `limit` is not `None`.
+
+`def _extract_text_for_ref_type(ref_type: str, metadata: dict) -> Optional[str]:` -- for `ref_type == "hadith"`: `decompress_text(metadata.get("text_en", "") or "")` or `None` if empty; for `ref_type == "quran_translation"`: `decompress_text(metadata.get("english_quran_translation", "") or "")`; for `ref_type == "tafsir_text"`: `decompress_text(metadata.get("text_chunk", "") or "")`.
+
+`def _index_name_for_ref_type(ref_type: str) -> str:` -- `DEEN_DENSE_INDEX_NAME` for `"hadith"`, `QURAN_DENSE_INDEX_NAME` for `"quran_translation"`/`"tafsir_text"`.
+
+`def run_batch(*, languages: list[str], ref_types: list[str], limit: Optional[int], dry_run: bool, model_name: str, translation_client, pc_client, session_factory) -> dict:` -- returns a nested summary dict `{ref_type: {language: count}}`. For each `ref_type` in `ref_types`: get `pc_index = pc_client.Index(_index_name_for_ref_type(ref_type))`; for each `(item_id, metadata)` in `_iter_source_items(pc_index, limit=limit)`: `text = _extract_text_for_ref_type(ref_type, metadata)`; skip if falsy; for each `language` in `languages`: increment `summary[ref_type][language]`; if `dry_run`: continue (no translate/upsert call at all); else: `translated = translate_text(translation_client, model=model_name, text=text, language=language)` then `upsert_translation(session_factory, ref_type=ref_type, ref_key=item_id, language=language, translated_text=translated, model_name=model_name)`. Wrap the per-item/per-language body in `try/except Exception:` that logs and continues (one bad item/language must not abort the whole run), matching the project's error-handling convention.
+
+`def main() -> None:` -- `args = parse_args()`; `languages = [l.strip().lower() for l in args.languages.split(",") if l.strip()]`; `ref_types = REF_TYPE_CHOICES if args.ref_type == "all" else [args.ref_type]`; `translation_client = None if args.dry_run else _get_translation_client()`; `pc_client = Pinecone(api_key=PINECONE_API_KEY)`; call `run_batch(...)` with `session_factory=SessionLocal`; `logger.info("Batch complete: %s", summary)`. Guard with `if __name__ == "__main__": main()`.
+
+Create `tests/test_translate_references.py` implementing every case in `<behavior>` above, modeled on `tests/test_ingest_fiqh.py`'s structure (module docstring stating these are mocked/no-network/no-DB tests). Build small fake classes for the Pinecone index (`.list()` yielding one or two pages of id lists, `.fetch()` returning a `SimpleNamespace(vectors={...})` where each vector is `SimpleNamespace(metadata={...})` with `core.utils.compress_text`-compressed sample text so `_extract_text_for_ref_type` round-trips correctly) and for the SQLAlchemy session factory (a context-manager-returning callable whose fake session records `.merge()`/`.commit()` calls). Patch `anthropic.Anthropic` for the `_get_translation_client` tests. Do not add `langdetect` or any other new third-party dependency.
+
+Finally, update `CLAUDE.md`: in the existing "## Commands" fenced bash block, after the "# Fiqh corpus ingestion / encoder regeneration" section, add a new commented section "# Reference translation batch job (DEE-67, personal key only -- do NOT run without setting TRANSLATION_ANTHROPIC_API_KEY)" with these exact example commands: `export TRANSLATION_ANTHROPIC_API_KEY=sk-ant-...   # personal key, never the app's ANTHROPIC_API_KEY`, `python scripts/translate_references.py --dry-run --limit 5   # preview counts, no Anthropic/DB calls`, `python scripts/translate_references.py --ref-type hadith --languages urdu --limit 20   # small live sample`, `python scripts/translate_references.py   # full corpus x all 6 languages (only after sampling looks correct)`, and a one-line note that `alembic upgrade head` must be run once (after Task 1's migration is authored) before this script's writes will succeed.
+  </action>
+  <verify>
+    <automated>cd /Users/admin2/deen-backend && python -m py_compile scripts/translate_references.py && python -m pytest tests/test_translate_references.py -q -x 2>&1 | tail -30</automated>
+  </verify>
+  <done>
+    - `scripts/translate_references.py` exists, is syntactically valid, and is re-runnable/idempotent (`upsert_translation` uses `Session.merge()` keyed by the composite PK)
+    - The script never imports or reads `ANTHROPIC_API_KEY` / `core.chat_models` -- only `TRANSLATION_ANTHROPIC_API_KEY` via the raw `anthropic` SDK
+    - `--dry-run` never calls the Anthropic client or writes to the database (proven by mocked tests)
+    - `CLAUDE.md` documents the exact start-to-finish commands (dry-run, small sample, full run) and the `alembic upgrade head` prerequisite
+    - `pytest tests/test_translate_references.py -q` passes with zero network/DB calls
+    - This task does NOT execute `scripts/translate_references.py` against any live service
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client `language` query param -> Postgres lookup | User-supplied string flows into `services/reference_translation_service.py`'s `select().where(..., ReferenceTranslation.language == language)` |
+| client `language` / `target_language` -> SSE response body | Selected-language translation text (MT-sourced, from the sidecar table) is returned to the client alongside EN/AR |
+| operator's personal `TRANSLATION_ANTHROPIC_API_KEY` -> `scripts/translate_references.py` | Dedicated credential, isolated from the app's `ANTHROPIC_API_KEY`, read only from the environment |
+| batch script -> Postgres (`db/session.py` sync engine) | Offline, human-triggered write path; no HTTP surface |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-pxt-01 | Tampering | `language` query param used in `ReferenceTranslation.language == language` | mitigate | SQLAlchemy ORM `select().where()` uses parameter binding -- no raw string SQL is ever constructed from user input, so standard SQL injection is structurally not possible here |
+| T-pxt-02 | Information Disclosure | `alookup_translations` DB errors | mitigate | Exceptions are caught, logged server-side only (`logger.error(..., exc_info=True)`), and the function returns `{}` -- no internal DB error detail is ever surfaced to the HTTP/SSE response, matching the project's existing tool-error-dict convention |
+| T-pxt-03 | Tampering (secrets) | `TRANSLATION_ANTHROPIC_API_KEY` handling in `scripts/translate_references.py` | mitigate | Read only via `os.getenv`, never logged, never written to the DB or any file; the app's `ANTHROPIC_API_KEY`/`core.chat_models` are never imported into this script, keeping the two credentials structurally isolated |
+| T-pxt-04 | Denial of Service (cost) | Accidental full-corpus live run of the batch job | mitigate | `--dry-run` and `--limit` are the documented default-safe entry points in `CLAUDE.md`; the script is never invoked by application code, a route, or CI -- it is a manually-triggered, human-run CLI tool only, and this task does not execute it |
+| T-pxt-05 | Tampering (content fidelity) | MT-translated religious reference text served to end users | accept | Mentor-approved workflow (see CONTEXT.md / memory `dee63-translation-review-workflow`): MT ships by default, `reviewed_at` provides a nullable spot-review hedge, and the `TRANSLATION_SYSTEM_PROMPT` explicitly instructs faithful literal translation with no added interpretation/fatwa language, per the CLAUDE.md religious-sensitivity hard rule |
+| T-pxt-SC | Tampering | npm/pip/cargo installs | accept | No new third-party dependencies added anywhere in this plan -- `anthropic`, `sqlalchemy`, `pinecone`, `pytest-asyncio` are all already pinned in `requirements.txt` |
+</threat_model>
+
+<verification>
+Run the new deterministic suites plus a broader regression check:
+
+```bash
+cd /Users/admin2/deen-backend && python -m pytest tests/test_reference_translations.py tests/test_translate_references.py -q -x 2>&1 | tail -40
+cd /Users/admin2/deen-backend && python -m pytest tests -q --ignore=tests/db 2>&1 | tail -40
+```
+
+Confirm the migration chains cleanly (requires local `.env` DB settings, matching the existing `alembic upgrade head` setup step already documented in `CLAUDE.md`):
+
+```bash
+cd /Users/admin2/deen-backend && alembic heads
+```
+
+Confirm the batch script is syntactically valid and its tests never touch a live service:
+
+```bash
+cd /Users/admin2/deen-backend && python -m py_compile scripts/translate_references.py
+```
+</verification>
+
+<success_criteria>
+- `POST /references?language=<lang>` returns hadith references with `text`/`text_ar` unchanged plus `text_translated`/`translated_language`, falling back to `null` when no translation row exists yet
+- SSE `hadith_references`/`quran_references` events on `POST /chat/stream/agentic` carry the same selected-language fields, driven by the existing `target_language`
+- `reference_translations` table exists via a clean-chaining Alembic migration (model + migration match exactly)
+- `scripts/translate_references.py` is a complete, re-runnable, idempotent batch job using a dedicated `TRANSLATION_ANTHROPIC_API_KEY` + configurable model (default `claude-sonnet-5`) -- but is NOT executed against any live service as part of this task
+- `CLAUDE.md` documents exact start-to-finish commands for the batch job
+- All new tests are deterministic (mocked, no network/DB) and pass; no regressions in `pytest tests -q --ignore=tests/db`
+- No new third-party dependencies added
+- Pinecone retrieval/vector search code paths are unmodified
+</success_criteria>
+
+<output>
+Create `.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-SUMMARY.md
+++ b/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-SUMMARY.md
@@ -1,0 +1,137 @@
+---
+phase: 260707-pxt
+plan: 01
+subsystem: api
+tags: [postgres, sqlalchemy, alembic, sse, langgraph, anthropic, pinecone, i18n]
+
+# Dependency graph
+requires: []
+provides:
+  - "reference_translations Postgres sidecar table (model + migration) keyed on (ref_type, ref_key, language)"
+  - "services/reference_translation_service.py::alookup_translations async lookup, never raises"
+  - "core/utils.py async formatter wrappers (aformat_references_as_json, aformat_quran_references_as_json) joining MT translations after retrieval"
+  - "POST /references language query param threaded to core.pipeline.references_pipeline"
+  - "hadith_references/quran_references SSE events on /chat/stream/agentic carry selected-language fields"
+  - "scripts/translate_references.py re-runnable offline batch MT job (built, not run) using a dedicated TRANSLATION_ANTHROPIC_API_KEY"
+affects: [api, chat-sse, references]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Join-after-retrieval sidecar lookup: Pinecone retrieval/ranking untouched, translations merged onto already-formatted reference dicts via a Postgres sidecar table"
+    - "Async wrapper around existing sync formatter functions (aformat_* calls format_* first, then additively merges translation fields)"
+    - "Dedicated-credential isolation for offline batch jobs: raw anthropic SDK client + separate env var, never core.chat_models / app ANTHROPIC_API_KEY"
+
+key-files:
+  created:
+    - db/models/reference_translations.py
+    - alembic/versions/20260707_create_reference_translations_table.py
+    - services/reference_translation_service.py
+    - scripts/translate_references.py
+    - tests/test_reference_translations.py
+    - tests/test_translate_references.py
+  modified:
+    - core/utils.py
+    - core/pipeline.py
+    - api/reference.py
+    - core/pipeline_langgraph.py
+    - CLAUDE.md
+
+key-decisions:
+  - "Single unified reference_translations table with a ref_type discriminator (hadith/quran_translation/tafsir_text) + ref_key + language composite PK, rather than per-type tables"
+  - "ref_key resolution: hadith_id for ref_type=hadith; Pinecone vector chunk_id for quran_translation/tafsir_text (two rows share the same chunk_id since a chunk has two independently-translatable fields)"
+  - "New response fields are additive: text_translated/translated_language (hadith), quran_translation_translated/tafsir_text_translated/translated_language (Quran/tafsir) -- existing text/text_ar/quran_translation/tafsir_text fields are never modified"
+  - "No DB lookup performed when language is unset or 'english' -- avoids an unnecessary round trip for the default case"
+  - "Batch MT script reads TRANSLATION_ANTHROPIC_API_KEY only, via the raw anthropic SDK -- never core.chat_models or the app's ANTHROPIC_API_KEY -- keeping personal translation spend structurally isolated from production usage"
+
+requirements-completed: [DEE-67]
+
+# Metrics
+duration: ~35min
+completed: 2026-07-07
+---
+
+# Phase 260707-pxt Plan 01: DEE-67 reference-lookup selected-language translations Summary
+
+**Postgres sidecar `reference_translations` table + join-after-retrieval async lookup threading a selected `language` through `POST /references` and the `hadith_references`/`quran_references` SSE events, plus a built-but-not-run offline batch MT job on a dedicated `TRANSLATION_ANTHROPIC_API_KEY` + `claude-sonnet-5`.**
+
+## Performance
+
+- **Duration:** ~35 min (includes fresh venv build + full dependency install for offline verification)
+- **Tasks:** 3/3 completed
+- **Files modified:** 11 (6 created, 5 modified)
+
+## Accomplishments
+- `reference_translations` table (composite PK `ref_type`/`ref_key`/`language` + provenance columns) with a clean-chaining Alembic migration onto the existing `onboarding_profiles_001` head
+- Async join-after-retrieval lookup service + `core/utils.py` async formatter wrappers, wired into both `POST /references` and the agentic SSE `hadith_references`/`quran_references` events, with EN/AR fallback (`None`) when no translation row exists
+- Re-runnable, idempotent offline batch MT script (`scripts/translate_references.py`) with strict credential isolation (`TRANSLATION_ANTHROPIC_API_KEY` via the raw `anthropic` SDK, never the app's key) -- built but intentionally NOT executed against any live service
+- 17 new deterministic mocked tests (9 + 8), zero network/DB calls, all passing
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: reference_translations table (model + migration)** - `067ce75` (feat)
+2. **Task 2: Join-after-retrieval translation lookup, wired into /references and SSE reference events** - `6214f4d` (feat, tdd)
+3. **Task 3: Offline batch MT job (build only, do not run) + documented commands** - `66d447d` (feat, tdd)
+
+_Note: this plan's tasks were marked `tdd="true"` in the plan frontmatter but executed as single feat commits with tests included in the same commit (test-first development happened during authoring, not as separate RED/GREEN git commits) -- see TDD Gate Compliance note below._
+
+## Files Created/Modified
+- `db/models/reference_translations.py` - `ReferenceTranslation` SQLAlchemy model, composite PK `(ref_type, ref_key, language)` + `source`/`translated_at`/`model`/`reviewed_at` provenance columns
+- `alembic/versions/20260707_create_reference_translations_table.py` - migration `reference_translations_001`, `down_revision = 'onboarding_profiles_001'`
+- `services/reference_translation_service.py` - `alookup_translations(ref_type, ref_keys, language) -> dict[str, str]`, opens its own `AsyncSessionLocal`, never raises (returns `{}` on error or empty input)
+- `core/utils.py` - `aformat_references_as_json` / `aformat_quran_references_as_json` async wrappers around the existing sync formatters, additive translation fields, no DB call for unset/`"english"` language
+- `core/pipeline.py` - `references_pipeline` gained a `language: str = "english"` parameter, threaded to `utils.aformat_references_as_json`
+- `api/reference.py` - new `language` `Query(...)` param on `POST /references`, mirroring the existing `sect`/`limit` pattern
+- `core/pipeline_langgraph.py` - `hadith_references`/`quran_references` SSE events now built via the async formatters, passing the existing in-scope `target_language`
+- `scripts/translate_references.py` - offline batch MT job (`parse_args`, `_get_translation_client`, `translate_text`, `upsert_translation`, `_iter_source_items`, `_extract_text_for_ref_type`, `run_batch`, `main`)
+- `tests/test_reference_translations.py` - 9 deterministic tests covering the lookup service, both async formatters, and pipeline language threading
+- `tests/test_translate_references.py` - 8 deterministic tests covering CLI parsing, client key isolation, `translate_text`, `upsert_translation`, and `run_batch` (dry-run safety, `--limit` sampling, live-path call counts)
+- `CLAUDE.md` - documented the batch job's start-to-finish commands and the `alembic upgrade head` prerequisite
+
+## Decisions Made
+- Single `reference_translations` table with a `ref_type` discriminator rather than per-type tables (simplest design handling both hadith and Quran/tafsir key schemes)
+- Quran/tafsir `ref_key` = the existing, stable Pinecone vector `chunk_id` -- no synthesized composite key needed; `quran_translation` and `tafsir_text` are separate rows sharing the same `chunk_id` since one chunk has two independently-translatable fields
+- Response field naming: `text_translated`/`translated_language` (hadith) and `quran_translation_translated`/`tafsir_text_translated`/`translated_language` (Quran/tafsir) -- purely additive, existing `text`/`text_ar`/`quran_translation`/`tafsir_text` fields untouched
+- `alookup_translations` never raises -- DB errors are logged server-side only and the function returns `{}`, matching the project's existing tool-error-dict convention (mirrors `agents/tools/*` error handling)
+- Batch script isolation: `TRANSLATION_ANTHROPIC_API_KEY` read only via `os.getenv`, raw `anthropic.Anthropic` client, no import of `core.chat_models` or `core.config.ANTHROPIC_API_KEY` anywhere in `scripts/translate_references.py`
+
+## Deviations from Plan
+
+None - plan executed exactly as written. The only environment-level addition was building a project-local `venv/` inside the worktree (not part of any task's file list) purely to run the deterministic offline verification commands specified in the plan's `<verification>` block -- no application code was affected, and `torch==2.6.0` was substituted with `torch==2.2.2` in the install (matching prior tasks' documented workaround for the local dev environment, no wheel available); this substitution has zero bearing on the DEE-67 test suites, which never import `torch` or any embedding module.
+
+## Issues Encountered
+
+None blocking. The pre-existing venv at the main repo path (`/Users/admin2/deen-backend/venv`) was empty (only `pip`/`setuptools`), so a fresh venv was created inside the worktree and the full `requirements.txt` (with the `torch` substitution above) was installed to run the deterministic tests offline.
+
+## TDD Gate Compliance
+
+Tasks 2 and 3 were marked `tdd="true"` in the plan frontmatter. Implementation code and its corresponding test file were authored together and committed in a single `feat(...)` commit per task, rather than as separate `test(...)` (RED) → `feat(...)` (GREEN) git commits. All tests were verified passing before each commit (RED→GREEN discipline was followed during authoring; it is just not reflected as separate git history). No `test(...)`-prefixed commit exists in this plan's history for gate-sequence validation purposes -- flagging per the plan-level TDD gate enforcement instructions.
+
+## User Setup Required
+
+**This task deliberately did NOT run `alembic upgrade head` or the batch MT job.** Two manual steps remain, both requiring a live environment this worktree does not have:
+
+1. **Apply the migration** (requires a reachable Postgres, e.g. Supabase): `alembic upgrade head` -- creates the `reference_translations` table. Until this runs, `POST /references?language=<lang>` and the SSE reference events will return `text_translated`/`translated_language` (and Quran/tafsir equivalents) as `null` for every reference (safe EN/AR fallback, does not error).
+2. **Populate the corpus** (personal key, optional/ops-triggered, only after step 1):
+   ```bash
+   export TRANSLATION_ANTHROPIC_API_KEY=sk-ant-...   # personal key, never the app's ANTHROPIC_API_KEY
+   python scripts/translate_references.py --dry-run --limit 5   # preview counts, no Anthropic/DB calls
+   python scripts/translate_references.py --ref-type hadith --languages urdu --limit 20   # small live sample
+   python scripts/translate_references.py   # full corpus x all 6 languages (only after sampling looks correct)
+   ```
+
+## Next Phase Readiness
+- API and SSE surfaces are fully wired end-to-end and covered by deterministic tests; no further code changes needed for DEE-67 to function once the migration is applied
+- Corpus population is a separate, human-triggered ops task on the user's personal key -- not blocking for this plan's completion
+- No regressions introduced: the 15 pre-existing test failures in `tests -q --ignore=tests/db` (in `test_agentic_streaming_pipeline.py`, `test_agentic_streaming_sse.py`, `test_async_concurrency_full.py`, `test_chat_agent_async.py`, `test_fiqh_integration.py`, `test_primer_service.py`) were verified identical on the pre-change base commit via a throwaway comparison worktree -- none are caused by this plan's changes
+
+---
+*Phase: 260707-pxt*
+*Completed: 2026-07-07*
+
+## Self-Check: PASSED
+
+All 11 files created/modified confirmed present on disk; all 3 task commit hashes (`067ce75`, `6214f4d`, `66d447d`) confirmed in `git log --oneline --all`.

--- a/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-VERIFICATION.md
+++ b/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-VERIFICATION.md
@@ -1,0 +1,122 @@
+---
+phase: 260707-pxt
+verified: 2026-07-07T00:00:00Z
+status: human_needed
+score: 6/6 must-haves verified (code inspection)
+has_blocking_gaps: false
+overrides_applied: 0
+human_verification:
+  - test: "Run `alembic upgrade head` against a reachable Postgres (e.g. Supabase) and then `alembic heads`"
+    expected: "Migration `reference_translations_001` applies cleanly on top of `onboarding_profiles_001`; `alembic heads` resolves to exactly one head (`reference_translations_001`); `reference_translations` table exists with the 8 documented columns and composite PK `(ref_type, ref_key, language)`"
+    why_human: "This environment has no reachable Postgres and no `alembic` package installed in the native venv (torch==2.6.0 wheel gap blocks a full `pip install -r requirements.txt` on this Intel Mac) -- migration apply could not be executed or observed directly. Static inspection confirms no other migration file declares `onboarding_profiles_001` as its `down_revision`, so the chain is structurally a single linear DAG, but this is not a substitute for actually running the migration."
+  - test: "Run `pytest tests/test_reference_translations.py tests/test_translate_references.py -q` (17 tests expected) and separately `pytest tests -q --ignore=tests/db` to confirm no regressions"
+    expected: "17/17 new tests pass; the pre-existing suite shows the same failures as the base commit (15 failures in test_agentic_streaming_pipeline.py, test_agentic_streaming_sse.py, test_async_concurrency_full.py, test_chat_agent_async.py, test_fiqh_integration.py, test_primer_service.py per SUMMARY.md), with no new failures introduced by this change"
+    why_human: "`pytest` is not installed in this environment's native venv (`No module named pytest`) and no working venv with the full dependency set was available to this verifier. The executor's SUMMARY.md claims 17/17 passed using a separate worktree venv with a torch substitution, but per this task's adversarial-verification mandate that claim is not accepted as evidence -- it must be independently re-run and observed. Code inspection (below) confirms the test files exist, are syntactically valid (`py_compile` succeeded on all 8 modified/created .py files), and their assertions structurally match every behavior enumerated in the plan's `<behavior>` blocks for Task 2 and Task 3."
+  - test: "POST /references?language=urdu against a live server with the reference_translations table populated (or empty) -- manually confirm text_translated is present in the JSON response and null when no row exists"
+    expected: "Response items include text/text_ar unchanged plus text_translated (null pre-population) and translated_language='urdu'"
+    why_human: "No running server/DB in this environment; this is the standard end-to-end confirmation of wiring that code inspection strongly supports but cannot fully replace."
+---
+
+# Quick Task 260707-pxt: DEE-67 reference-lookup selected-language translations Verification Report
+
+**Task Goal:** Postgres sidecar table `reference_translations` + join-after-retrieval enrichment wired into `/references` and the SSE `hadith_references`/`quran_references` events with EN/AR fallback and a `language` input, plus an offline batch MT script (build-not-run) using a dedicated `TRANSLATION_ANTHROPIC_API_KEY` + `claude-sonnet-5` via the raw `anthropic` SDK.
+
+**Verified:** 2026-07-07 (code-inspection based; no live DB/pytest available in this environment)
+**Status:** human_needed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Sidecar model + migration exist, keyed for hadith + Quran/tafsir, provenance columns + nullable reviewed_at, NO status/reviewer state machine | VERIFIED | `db/models/reference_translations.py` defines exactly 8 columns: `ref_type, ref_key, language` (composite PK), `translated_text`, `source` (default `"mt"`), `translated_at` (server_default `func.now()`), `model`, `reviewed_at` (nullable). No `status`/`reviewer` columns anywhere. Migration `alembic/versions/20260707_create_reference_translations_table.py` mirrors the model exactly, `revision='reference_translations_001'`, `down_revision='onboarding_profiles_001'`. |
+| 2 | Translation added ALONGSIDE existing text/text_ar (existing keys untouched), threaded via `language` on /references and `target_language` on SSE, EN/AR fallback when row absent | VERIFIED | `core/utils.py::aformat_references_as_json`/`aformat_quran_references_as_json` call the original sync formatters first (`base = format_references_as_json(...)`), never modify the sync functions, and only add new keys (`text_translated`, `translated_language`, `quran_translation_translated`, `tafsir_text_translated`). `api/reference.py` adds a `language: str = Query("english", ...)` param passed to `pipeline.references_pipeline(user_query, sect, limit, language)`. `core/pipeline_langgraph.py` lines 516/520 pass the pre-existing `target_language` into the new async formatters. Missing rows resolve to `None` via `dict.get()` (no KeyError), confirmed both in code and in `tests/test_reference_translations.py::test_language_urdu_calls_lookup_once_and_merges` (asserts `result[1]["text_translated"] is None` for an unmatched key). |
+| 3 | Pinecone retrieval/vector search untouched -- translations joined AFTER retrieval only in the formatter layer | VERIFIED | `modules/retrieval/retriever.py` and `modules/reranking/reranker.py` show no diff in this change (git commit diffs only touch `api/reference.py`, `core/pipeline.py`, `core/pipeline_langgraph.py`, `core/utils.py`, `services/reference_translation_service.py`, `db/models/*`, `alembic/versions/*`, `scripts/translate_references.py`, `CLAUDE.md`, and the two new test files -- confirmed via `git show --stat` on all 3 task commits). The new async formatters call `format_references_as_json(retrieved_docs)` (the existing, unmodified sync formatter) before any DB lookup. |
+| 4 | `scripts/translate_references.py` uses `TRANSLATION_ANTHROPIC_API_KEY` + `claude-sonnet-5` via raw `anthropic` SDK, does NOT import `core.chat_models` or `core.config.ANTHROPIC_API_KEY`, and is not auto-run anywhere | VERIFIED | `scripts/translate_references.py` imports `from anthropic import Anthropic` (raw SDK, not `langchain_anthropic`). `_get_translation_client()` reads only `os.getenv("TRANSLATION_ANTHROPIC_API_KEY")`, raises `ValueError` mentioning that var name if unset. `DEFAULT_MODEL = "claude-sonnet-5"`. Grep confirms zero occurrences of `chat_models` as an import and zero references to `core.config.ANTHROPIC_API_KEY` (only docstring/comment mentions of the bare string `ANTHROPIC_API_KEY` for isolation documentation). `grep -rln "scripts.translate_references\|scripts/translate_references"` across the repo (excluding the script itself and its test file) returns nothing -- no route, no startup hook, no CI config invokes it. `main()` only runs under `if __name__ == "__main__":`. |
+| 5 | At request time most references have no matching row (migration not applied), so translated fields come back null and client falls back to EN/AR | VERIFIED (by design + code path) | Since `alembic upgrade head` was not run (confirmed: this is explicitly deferred, see human_verification below), the `reference_translations` table does not yet exist in any live DB touched by this task. `alookup_translations` is wrapped in `try/except Exception` and returns `{}` on any DB error (including "table does not exist"), so pre-migration behavior is a safe empty-dict fallback -- confirmed by `tests/test_reference_translations.py::test_returns_empty_dict_on_db_exception`. Post-migration-but-unpopulated behavior (table exists, zero rows) also correctly returns `{}` via the same `SELECT ... WHERE ... IN (...)` returning no rows. |
+| 6 | Alembic heads resolves to a single head after this migration, chaining cleanly onto the current head (`onboarding_profiles_001`) | UNCERTAIN (static chain verified; live command not run) | Static inspection of all 12 files in `alembic/versions/` confirms a single linear chain: `initial_schema_001 -> userid_to_string -> a12c6d22b9d9 -> baseline_primers_001 -> personalized_primers_001 -> embeddings_001 -> page_quiz_001 -> chat_history_001 -> memory_agent_001 -> embeddings_002 -> onboarding_profiles_001 -> reference_translations_001`. No other file declares `down_revision = 'onboarding_profiles_001'` (grep confirmed exactly one match: the new migration itself), so there is no branch/fork. `alembic heads` itself could not be run in this environment (alembic not installed in the native venv; no reachable Postgres) -- routed to human_verification. |
+
+**Score:** 5/6 truths VERIFIED by direct code inspection, 1/6 UNCERTAIN pending a live `alembic heads` run (structurally sound but unexecuted).
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `db/models/reference_translations.py` | `ReferenceTranslation` model, composite PK + provenance columns | VERIFIED | Exists, exact column set matches LOCKED schema, no extra columns |
+| `alembic/versions/20260707_create_reference_translations_table.py` | Migration, `reference_translations_001` / `down_revision=onboarding_profiles_001` | VERIFIED | Exists, matches model exactly, `downgrade()` drops the table |
+| `services/reference_translation_service.py` | `alookup_translations(ref_type, ref_keys, language) -> dict` | VERIFIED | Exists, self-contained `AsyncSessionLocal()` per call, never raises (broad `try/except` returns `{}`) |
+| `core/utils.py` | `aformat_references_as_json` / `aformat_quran_references_as_json` async wrappers | VERIFIED | Both exist immediately after the sync formatters, additive-only field merging, skip DB call when language unset/"english" |
+| `api/reference.py` | `language` Query param threaded to `references_pipeline` | VERIFIED | `Query("english", ...)` param added, passed positionally to `pipeline.references_pipeline` |
+| `core/pipeline.py` | `references_pipeline(..., language="english")` threading to `aformat_references_as_json` | VERIFIED | Signature updated, `await utils.aformat_references_as_json(docs, language)` replaces the old sync call |
+| `core/pipeline_langgraph.py` | SSE `hadith_references`/`quran_references` built via new async formatters with `target_language` | VERIFIED | Lines 516/520 confirmed `await utils.aformat_references_as_json(hadith_docs, target_language)` / `await utils.aformat_quran_references_as_json(quran_docs, target_language)` |
+| `scripts/translate_references.py` | Offline batch MT job, dedicated key, raw SDK, build-not-run | VERIFIED | Exists, `py_compile` clean, `TRANSLATION_ANTHROPIC_API_KEY`-only credential path, `Session.merge()` idempotent upsert, `--dry-run`/`--limit` safety flags, never invoked elsewhere in the repo |
+| `tests/test_reference_translations.py` | Deterministic mocked tests | VERIFIED (existence + content); NOT independently executed | 9 tests, all behaviors from the plan's `<behavior>` block are present and structurally correct (fake async session, fake result/scalars, patch targets match real call sites) |
+| `tests/test_translate_references.py` | Deterministic mocked tests for batch script | VERIFIED (existence + content); NOT independently executed | 8 tests (`parse_args`, `_get_translation_client` x2, `translate_text`, `upsert_translation`, `run_batch` x3), fake Pinecone index/session objects, patch targets match real function names |
+| `CLAUDE.md` | Start-to-finish run commands for batch job + `alembic upgrade head` step | VERIFIED | New "# Reference translation batch job (DEE-67...)" block added to the `## Commands` fenced bash section with all 4 documented commands plus a note that `alembic upgrade head` must run first |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| `api/reference.py` | `core/pipeline.py::references_pipeline` | `language: str = Query(...)` | WIRED | Confirmed by grep: `language: str = Query(` present, call site passes `language` positionally |
+| `core/pipeline.py::references_pipeline` | `core/utils.py::aformat_references_as_json` | `await utils.aformat_references_as_json(docs, language)` | WIRED | Confirmed at line 112 |
+| `core/pipeline_langgraph.py` | `core/utils.py::aformat_references_as_json` / `aformat_quran_references_as_json` | `await ...(docs, target_language)` before SSE yield | WIRED | Confirmed at lines 516, 520; `target_language` already in scope from function signature (line 149) |
+| `core/utils.py` | `services/reference_translation_service.py::alookup_translations` | join-after-retrieval lookup keyed by `hadith_id` / `chunk_id` | WIRED | `from services import reference_translation_service` imported at top of `core/utils.py`; both async formatters call `reference_translation_service.alookup_translations(...)` |
+| `services/reference_translation_service.py` | `db/models/reference_translations.py::ReferenceTranslation` | `select(ReferenceTranslation).where(...)` | WIRED | Confirmed `select(ReferenceTranslation).where(ReferenceTranslation.ref_type == ..., ReferenceTranslation.ref_key.in_(keys), ReferenceTranslation.language == language)` |
+| `scripts/translate_references.py` | `db/models/reference_translations.py::ReferenceTranslation` | `db.merge(row)` upsert | WIRED | Confirmed `upsert_translation()` constructs `ReferenceTranslation(...)`, calls `db.merge(row)` then `db.commit()` |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|---------------------|--------|
+| `aformat_references_as_json` | `text_translated` | `reference_translation_service.alookup_translations("hadith", hadith_ids, language)` -> real `SELECT` against `ReferenceTranslation` | Yes (real SQLAlchemy query, not a static stub) -- returns empty dict pre-migration/pre-population, which is documented and expected behavior, not a hollow/hardcoded stub | FLOWING (empty pending migration + corpus population, by design) |
+| `aformat_quran_references_as_json` | `quran_translation_translated`, `tafsir_text_translated` | Same lookup service, two concurrent `alookup_translations` calls via `asyncio.gather` | Same as above | FLOWING (empty pending migration + corpus population, by design) |
+| `scripts/translate_references.py::run_batch` | translated text | `translate_text()` -> real `client.messages.create()` call (Anthropic SDK), not a static return | Yes (only exercised live when `--dry-run` is absent) | N/A -- correctly gated by `dry_run`, intentionally not executed in this task |
+
+No hollow props or hardcoded-empty-return anti-patterns found; the `None`/`{}` fallbacks are explicit, intentional, and match the LOCKED "MT ships later, EN/AR fallback until then" decision in CONTEXT.md.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| All 8 modified/created Python files compile | `python -m py_compile scripts/translate_references.py db/models/reference_translations.py services/reference_translation_service.py core/utils.py core/pipeline.py api/reference.py core/pipeline_langgraph.py alembic/versions/20260707_create_reference_translations_table.py` | "ALL COMPILE OK" | PASS |
+| `pytest tests/test_reference_translations.py tests/test_translate_references.py -q` | attempted | `No module named pytest` (native venv has no pytest; torch==2.6.0 wheel gap on this Intel Mac blocks a full `pip install -r requirements.txt`, matching the documented environment limitation) | SKIP -> routed to human_verification |
+| `alembic heads` | attempted | `alembic not found` (not installed in native venv; no live Postgres reachable either) | SKIP -> routed to human_verification |
+| `chunk_id` field genuinely exists in retrieval output (not a hallucinated key name) | `grep -n "chunk_id" modules/retrieval/retriever.py` | Two matches, both `"chunk_id": match.id` (Pinecone match id) | PASS -- confirms the `ref_key` mapping documented in the model docstring and used by `aformat_quran_references_as_json` is grounded in real data |
+| Migration chain has no fork/branch onto `onboarding_profiles_001` | `grep -rln "down_revision = 'onboarding_profiles_001'" alembic/versions/` | Exactly one match: the new migration file itself | PASS |
+| `scripts/translate_references.py` not invoked anywhere else in the repo | `grep -rln "scripts.translate_references\|scripts/translate_references" --include="*.py" .` (excluding the script + its test) | No matches | PASS |
+
+### Probe Execution
+
+Not applicable -- no `scripts/*/tests/probe-*.sh` convention used by this task; PLAN.md declares no probes.
+
+### Requirements Coverage
+
+This is a quick-task workflow (no `.planning/REQUIREMENTS.md` phase mapping in this repo). Requirement `DEE-67` is declared in `260707-pxt-PLAN.md` frontmatter and traced end-to-end through the truths/artifacts/key-links above.
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|--------------|--------|----------|
+| DEE-67 | 260707-pxt-PLAN.md | Selected-language reference translations, sidecar table + join-after-retrieval + offline batch job | SATISFIED (code-level; live migration/test-run pending) | See truths 1-6 above |
+
+### Anti-Patterns Found
+
+None. No `TODO`/`FIXME`/`XXX`/`HACK`/`PLACEHOLDER` markers, no empty-handler stubs, no hardcoded-empty returns that bypass real logic, in any of the 11 created/modified files.
+
+### Human Verification Required
+
+See YAML frontmatter `human_verification` section. Summary:
+
+1. **Run `alembic upgrade head` + `alembic heads`** against a reachable Postgres to confirm the migration actually applies and the head resolves to exactly one revision. This environment has no live DB and no `alembic` package installed.
+2. **Run `pytest tests/test_reference_translations.py tests/test_translate_references.py -q`** (expect 17 passed) and **`pytest tests -q --ignore=tests/db`** to independently confirm the SUMMARY.md's "17 passed, 15 pre-existing unrelated failures" claim. This environment has no `pytest` installed in the native venv (documented torch==2.6.0 wheel gap on Intel Mac) and no alternate working venv was available to this verifier.
+3. **Manually hit `POST /references?language=urdu`** (and the SSE `/chat/stream/agentic` path) against a running server to visually confirm `text_translated`/`translated_language` appear in the JSON with the documented `null` fallback pre-population.
+
+### Gaps Summary
+
+No code-level gaps found. Every must-have artifact, truth, and key link is present, correctly implemented, and consistent with both the PLAN.md must_haves and the LOCKED decisions in CONTEXT.md. The task's own design intentionally defers two operational steps (migration apply, corpus population) to a live environment with Postgres access, which this verifier does not have. The only reason this report is not `passed` is that (a) the SUMMARY.md's test-pass claim cannot be independently reproduced in this sandbox (pytest not installed) and (b) `alembic heads` cannot be independently run (alembic not installed, no DB) -- both are routed to human_verification per the environment note rather than failed, since code inspection gives no reason to doubt them and the plan explicitly scoped migration-apply as a deferred manual step.
+
+---
+
+*Verified: 2026-07-07*
+*Verifier: Claude (gsd-verifier)*

--- a/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-VERIFICATION.md
+++ b/.planning/quick/260707-pxt-dee-67-reference-lookup-selected-languag/260707-pxt-VERIFICATION.md
@@ -1,9 +1,14 @@
 ---
 phase: 260707-pxt
 verified: 2026-07-07T00:00:00Z
-status: human_needed
-score: 6/6 must-haves verified (code inspection)
+status: passed
+score: 6/6 must-haves verified (code inspection + Docker test run + offline migration DDL)
 has_blocking_gaps: false
+test_execution:
+  deterministic: "docker compose run --rm -e REDIS_URL=redis://127.0.0.1:1/0 api pytest tests/test_reference_translations.py tests/test_translate_references.py -q -> 17 passed (user-confirmed in Docker)."
+  migration_offline: "docker compose run --rm api alembic upgrade onboarding_profiles_001:head --sql -> clean transactional CREATE TABLE reference_translations with composite PK + nullable reviewed_at. Valid."
+  migration_apply: "NOT applied to live DB — shared Supabase host unresolvable from local Docker (paused / IPv4-vs-pooler DNS). Applies at deploy via alembic upgrade head."
+  batch_job: "scripts/translate_references.py NOT run (build-only by design; needs personal TRANSLATION_ANTHROPIC_API_KEY + live services)."
 overrides_applied: 0
 human_verification:
   - test: "Run `alembic upgrade head` against a reachable Postgres (e.g. Supabase) and then `alembic heads`"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ python scripts/ingest_fiqh.py                  # full: parse PDF + embed + upser
 python scripts/ingest_fiqh.py --encoder-only   # local-only: regenerate data/fiqh_bm25_encoder.json
                                                 # (gitignored; required for fiqh queries to work locally)
 
+# Reference translation batch job (DEE-67, personal key only -- do NOT run without setting TRANSLATION_ANTHROPIC_API_KEY)
+export TRANSLATION_ANTHROPIC_API_KEY=sk-ant-...   # personal key, never the app's ANTHROPIC_API_KEY
+python scripts/translate_references.py --dry-run --limit 5   # preview counts, no Anthropic/DB calls
+python scripts/translate_references.py --ref-type hadith --languages urdu --limit 20   # small live sample
+python scripts/translate_references.py   # full corpus x all 6 languages (only after sampling looks correct)
+# Note: run `alembic upgrade head` once (creates the reference_translations table) before this script's writes will succeed.
+
 # Docker
 docker compose build --no-cache && docker compose up -d
 

--- a/alembic/versions/20260707_create_reference_translations_table.py
+++ b/alembic/versions/20260707_create_reference_translations_table.py
@@ -1,0 +1,32 @@
+"""create reference translations table
+
+Revision ID: reference_translations_001
+Revises: onboarding_profiles_001
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'reference_translations_001'
+down_revision = 'onboarding_profiles_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'reference_translations',
+        sa.Column('ref_type', sa.Text(), primary_key=True, nullable=False),
+        sa.Column('ref_key', sa.Text(), primary_key=True, nullable=False),
+        sa.Column('language', sa.Text(), primary_key=True, nullable=False),
+        sa.Column('translated_text', sa.Text(), nullable=False),
+        sa.Column('source', sa.Text(), nullable=False, server_default='mt'),
+        sa.Column('translated_at', sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column('model', sa.Text(), nullable=False),
+        sa.Column('reviewed_at', sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('reference_translations')

--- a/api/reference.py
+++ b/api/reference.py
@@ -25,6 +25,10 @@ async def references_pipeline(
     credentials: JWTAuthorizationCredentials = Depends(auth),
     sect: str = Query("both", enum=["sunni", "shia", "both"]),
     limit: int = Query(10, ge=1, le=50, description="Number of references to fetch (1-50)"),
+    language: str = Query(
+        "english",
+        description="Selected language for translated reference text (e.g. 'arabic', 'farsi', 'urdu', 'german', 'bahasa melayu', 'french'). Defaults to English -- no translation join performed.",
+    ),
 ):
     user_query = request.user_query.strip()
     corr_id = correlation_id_ctx.get()
@@ -38,7 +42,7 @@ async def references_pipeline(
         raise HTTPException(status_code=400, detail="Please provide an appropriate query.")
 
     try:
-        results = await pipeline.references_pipeline(user_query, sect, limit)
+        results = await pipeline.references_pipeline(user_query, sect, limit, language)
         logger.info(
             "References request completed",
             extra={"correlation_id": corr_id, "endpoint": "/references"},

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -85,10 +85,14 @@ def chat_pipeline_streaming(user_query: str, session_id: str, target_language: s
 
 
 
-async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT):
+async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE_FETCH_COUNT, language: str = "english"):
     """Async references pipeline (DEE-44). Uses native `aclassify_*`,
     `aenhance_query`, and `aretrieve_*` so the route doesn't block the event
-    loop on classification → enhancement → retrieval → ranking."""
+    loop on classification → enhancement → retrieval → ranking.
+
+    `language` (DEE-67) threads through to `utils.aformat_references_as_json`,
+    which joins in a selected-language translation from the Postgres sidecar
+    table -- retrieval/ranking above is unaffected."""
     is_non_islamic = await classifier.aclassify_non_islamic_query(user_query)
     if is_non_islamic:
         return "This question is not related to the domain of Islamic education. Please ask relevant questions."
@@ -105,7 +109,7 @@ async def references_pipeline(user_query: str, sect: str, limit: int = REFERENCE
     # Run shia + sunni retrievals concurrently when both are requested.
     fetched = await asyncio.gather(*[fut for _, fut in fetches])
     for (label, _), docs in zip(fetches, fetched):
-        results[label] = utils.format_references_as_json(docs)
+        results[label] = await utils.aformat_references_as_json(docs, language)
 
     return results
 

--- a/core/pipeline_langgraph.py
+++ b/core/pipeline_langgraph.py
@@ -513,11 +513,11 @@ async def chat_pipeline_streaming_agentic(
                     history_written = True
 
                 if hadith_docs:
-                    hadith_json = utils.format_references_as_json(hadith_docs)
+                    hadith_json = await utils.aformat_references_as_json(hadith_docs, target_language)
                     yield sse_event("hadith_references", {"references": hadith_json})
 
                 if quran_docs:
-                    quran_json = utils.format_quran_references_as_json(quran_docs)
+                    quran_json = await utils.aformat_quran_references_as_json(quran_docs, target_language)
                     yield sse_event("quran_references", {"references": quran_json})
 
             _emit_cache_metrics_breadcrumb(final_state)

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,11 @@
 from langchain_core.documents import Document
+import asyncio
 import traceback
 import base64
 import gzip
+from typing import Optional
+
+from services import reference_translation_service
 
 def compact_format_references(retrieved_docs: list, max_chars: int = 1500) -> str:
     """
@@ -292,6 +296,66 @@ def format_quran_references_as_json(quran_docs: list) -> list:
         print(f"Error formatting Quran references: {e}")
         traceback.print_exc()
     return result
+
+
+async def aformat_references_as_json(retrieved_docs: list, language: Optional[str] = None) -> list:
+    """Async wrapper around `format_references_as_json` that additionally joins in a
+    selected-language translation (DEE-67), sourced from the `reference_translations`
+    Postgres sidecar table -- NOT from Pinecone metadata. Existing `text`/`text_ar`
+    fields are left untouched; the new `text_translated`/`translated_language` fields
+    are additive.
+
+    When `language` is unset or "english", no DB lookup is performed -- both new
+    fields are simply set to None.
+    """
+    base = format_references_as_json(retrieved_docs)
+    normalized_language = (language or "").strip().lower()
+
+    if not normalized_language or normalized_language == "english":
+        for ref in base:
+            ref["text_translated"] = None
+            ref["translated_language"] = None
+        return base
+
+    hadith_ids = [ref.get("hadith_id") for ref in base]
+    translations = await reference_translation_service.alookup_translations(
+        "hadith", hadith_ids, normalized_language
+    )
+    for ref in base:
+        ref["text_translated"] = translations.get(str(ref.get("hadith_id")))
+        ref["translated_language"] = normalized_language
+    return base
+
+
+async def aformat_quran_references_as_json(quran_docs: list, language: Optional[str] = None) -> list:
+    """Async wrapper around `format_quran_references_as_json` that additionally joins
+    in selected-language translations (DEE-67) for both the Quran verse translation
+    and the tafsir commentary, keyed by the Pinecone vector `chunk_id`.
+
+    Because the underlying sync formatter's single try/except wraps its whole loop
+    (it can return a shorter list than `quran_docs` on error), `chunk_ids` is built
+    with a defensive slice to keep it aligned 1:1 with `base`.
+    """
+    base = format_quran_references_as_json(quran_docs)
+    chunk_ids = [doc.get("chunk_id") for doc in (quran_docs or [])[: len(base)]]
+    normalized_language = (language or "").strip().lower()
+
+    if not normalized_language or normalized_language == "english":
+        for ref in base:
+            ref["quran_translation_translated"] = None
+            ref["tafsir_text_translated"] = None
+            ref["translated_language"] = None
+        return base
+
+    translation_lookup, tafsir_lookup = await asyncio.gather(
+        reference_translation_service.alookup_translations("quran_translation", chunk_ids, normalized_language),
+        reference_translation_service.alookup_translations("tafsir_text", chunk_ids, normalized_language),
+    )
+    for ref, chunk_id in zip(base, chunk_ids):
+        ref["quran_translation_translated"] = translation_lookup.get(str(chunk_id))
+        ref["tafsir_text_translated"] = tafsir_lookup.get(str(chunk_id))
+        ref["translated_language"] = normalized_language
+    return base
 
 
 def format_fiqh_references_as_json(fiqh_docs: list) -> list:

--- a/db/models/reference_translations.py
+++ b/db/models/reference_translations.py
@@ -1,0 +1,38 @@
+"""SQLAlchemy model for the `reference_translations` Postgres sidecar table (DEE-67).
+
+Stores machine-translated text for hadith / Quran / tafsir references, keyed by a
+composite primary key of (ref_type, ref_key, language). This is a join-after-retrieval
+sidecar -- Pinecone metadata and the retrieval/ranking path are untouched; translations
+are looked up separately by `services/reference_translation_service.py` and merged onto
+the formatted reference dicts in `core/utils.py`.
+
+`ref_key` resolution by `ref_type` (see CONTEXT.md "multiple reference types with
+different id schemes" concern):
+    - ref_type == "hadith"            -> ref_key is the hadith's `hadith_id`
+                                          (already present in Pinecone hadith metadata)
+    - ref_type == "quran_translation" -> ref_key is the Pinecone vector `chunk_id`
+    - ref_type == "tafsir_text"       -> ref_key is the same Pinecone vector `chunk_id`
+
+`quran_translation` and `tafsir_text` deliberately share the same `ref_key` (the chunk's
+Pinecone vector id) but are stored as separate rows/ref_types, because a single Quran/
+tafsir chunk has two independently-translatable fields (the Quran verse translation and
+the tafsir commentary). Quran/tafsir chunks already have a stable, existing Pinecone
+vector ID, so no synthesized composite key is needed.
+"""
+from sqlalchemy import Column, Text, TIMESTAMP
+from sqlalchemy.sql import func
+
+from ..session import Base
+
+
+class ReferenceTranslation(Base):
+    __tablename__ = "reference_translations"
+
+    ref_type = Column(Text, primary_key=True, nullable=False)
+    ref_key = Column(Text, primary_key=True, nullable=False)
+    language = Column(Text, primary_key=True, nullable=False)
+    translated_text = Column(Text, nullable=False)
+    source = Column(Text, nullable=False, server_default="mt")
+    translated_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    model = Column(Text, nullable=False)
+    reviewed_at = Column(TIMESTAMP(timezone=True), nullable=True)

--- a/scripts/translate_references.py
+++ b/scripts/translate_references.py
@@ -1,0 +1,279 @@
+"""
+Offline batch MT job for DEE-67: translate the hadith + quran_translation + tafsir_text
+reference corpus into the `reference_translations` Postgres sidecar table, across the
+6 canonical languages.
+
+This is a re-runnable, idempotent, human-triggered CLI tool -- it is NEVER invoked by
+application code, a route, or CI. It uses a DEDICATED personal Anthropic API key
+(`TRANSLATION_ANTHROPIC_API_KEY`), never the app's `ANTHROPIC_API_KEY` / `core.chat_models`,
+so translation cost/usage is fully isolated from the running app's key.
+
+Usage:
+    export TRANSLATION_ANTHROPIC_API_KEY=sk-ant-...   # personal key, never the app's ANTHROPIC_API_KEY
+    python scripts/translate_references.py --dry-run --limit 5   # preview counts, no Anthropic/DB calls
+    python scripts/translate_references.py --ref-type hadith --languages urdu --limit 20   # small live sample
+    python scripts/translate_references.py   # full corpus x all 6 languages (only after sampling looks correct)
+
+`alembic upgrade head` must be run once (after the reference_translations_001 migration
+is authored) before this script's writes will succeed.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+# Add project root to sys.path (required for local imports)
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from anthropic import Anthropic
+from pinecone import Pinecone
+
+from core.config import DEEN_DENSE_INDEX_NAME, PINECONE_API_KEY, QURAN_DENSE_INDEX_NAME
+from core.logging_config import setup_logging
+from core.utils import decompress_text
+from db.models.reference_translations import ReferenceTranslation
+from db.session import SessionLocal
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------ #
+# Constants
+# ------------------------------------------------------------------ #
+
+SUPPORTED_LANGUAGES = ["arabic", "farsi", "urdu", "german", "bahasa melayu", "french"]
+REF_TYPE_CHOICES = ["hadith", "quran_translation", "tafsir_text"]
+DEFAULT_MODEL = "claude-sonnet-5"
+
+TRANSLATION_SYSTEM_PROMPT = (
+    "You are a faithful, literal translator of Twelver Shia Islamic reference texts "
+    "(hadith, Quran translations, and tafsir commentary) into {language}. "
+    "Preserve all meaning, terminology, honorifics, and the Twelver Shia theological "
+    "framing of the source text exactly. Do not add interpretation, commentary, "
+    "opinion, or fatwa-like guidance of your own. Do not omit or summarize any part "
+    "of the text. Return ONLY the translated text, with no preamble, explanation, or "
+    "additional commentary."
+)
+
+
+# ------------------------------------------------------------------ #
+# CLI / client setup
+# ------------------------------------------------------------------ #
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """Parse CLI arguments for the batch translation job."""
+    parser = argparse.ArgumentParser(
+        description="Batch-translate the hadith/Quran/tafsir reference corpus into reference_translations"
+    )
+    parser.add_argument(
+        "--languages",
+        default=",".join(SUPPORTED_LANGUAGES),
+        help="Comma-separated list of target languages (default: all 6 canonical languages)",
+    )
+    parser.add_argument(
+        "--ref-type",
+        choices=REF_TYPE_CHOICES + ["all"],
+        default="all",
+        help="Which reference type to translate (default: all)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview counts only; never call Anthropic or write to the database",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap number of source items enumerated per ref_type, for sampling",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Translation model/version string (default: {DEFAULT_MODEL})",
+    )
+    return parser.parse_args(argv)
+
+
+def _get_translation_client() -> Anthropic:
+    """Construct the raw Anthropic SDK client from the DEDICATED translation key.
+
+    Never reads ANTHROPIC_API_KEY (the app's key) -- this isolation is a LOCKED
+    requirement (see CONTEXT.md / PLAN.md T-pxt-03).
+    """
+    api_key = os.getenv("TRANSLATION_ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "TRANSLATION_ANTHROPIC_API_KEY is not set. This batch job requires a dedicated "
+            "personal Claude API key, separate from the app's ANTHROPIC_API_KEY, so translation "
+            "cost/usage never touches the running app's key. Set TRANSLATION_ANTHROPIC_API_KEY "
+            "before running."
+        )
+    return Anthropic(api_key=api_key)
+
+
+# ------------------------------------------------------------------ #
+# Translation + upsert
+# ------------------------------------------------------------------ #
+
+def translate_text(client, *, model: str, text: str, language: str) -> str:
+    """Translate a single piece of reference text into `language` via the raw Anthropic SDK."""
+    response = client.messages.create(
+        model=model,
+        max_tokens=2048,
+        system=TRANSLATION_SYSTEM_PROMPT.format(language=language),
+        messages=[{"role": "user", "content": text}],
+    )
+    return response.content[0].text.strip()
+
+
+def upsert_translation(
+    session_factory,
+    *,
+    ref_type: str,
+    ref_key: str,
+    language: str,
+    translated_text: str,
+    model_name: str,
+) -> None:
+    """Idempotent upsert of a single translated row, keyed by the composite PK."""
+    with session_factory() as db:
+        row = ReferenceTranslation(
+            ref_type=ref_type,
+            ref_key=str(ref_key),
+            language=language,
+            translated_text=translated_text,
+            source="mt",
+            translated_at=datetime.now(timezone.utc),
+            model=model_name,
+        )
+        db.merge(row)
+        db.commit()
+
+
+# ------------------------------------------------------------------ #
+# Corpus enumeration
+# ------------------------------------------------------------------ #
+
+def _iter_source_items(
+    pc_index, *, namespace: str = "ns1", limit: Optional[int] = None
+) -> Iterator[tuple[str, dict]]:
+    """Yield (item_id, metadata_dict) tuples by paging through a Pinecone index's
+    `.list()` (id pages) and `.fetch()` (id -> vector w/ metadata), stopping once
+    `limit` items have been yielded (if `limit` is not None)."""
+    yielded = 0
+    for page_ids in pc_index.list(namespace=namespace):
+        if not page_ids:
+            continue
+        fetched = pc_index.fetch(ids=page_ids, namespace=namespace)
+        for vector_id, vector in fetched.vectors.items():
+            yield vector_id, (vector.metadata or {})
+            yielded += 1
+            if limit is not None and yielded >= limit:
+                return
+
+
+def _extract_text_for_ref_type(ref_type: str, metadata: dict) -> Optional[str]:
+    """Extract and decompress the source-language text for a given ref_type from
+    raw Pinecone metadata."""
+    if ref_type == "hadith":
+        raw = metadata.get("text_en", "") or ""
+    elif ref_type == "quran_translation":
+        raw = metadata.get("english_quran_translation", "") or ""
+    elif ref_type == "tafsir_text":
+        raw = metadata.get("text_chunk", "") or ""
+    else:
+        return None
+    return decompress_text(raw) or None
+
+
+def _index_name_for_ref_type(ref_type: str) -> str:
+    if ref_type == "hadith":
+        return DEEN_DENSE_INDEX_NAME
+    return QURAN_DENSE_INDEX_NAME
+
+
+# ------------------------------------------------------------------ #
+# Batch runner
+# ------------------------------------------------------------------ #
+
+def run_batch(
+    *,
+    languages: list[str],
+    ref_types: list[str],
+    limit: Optional[int],
+    dry_run: bool,
+    model_name: str,
+    translation_client,
+    pc_client,
+    session_factory,
+) -> dict:
+    """Run the batch translation job. Returns a nested summary dict
+    {ref_type: {language: count}} of items that were (or, on --dry-run, would be)
+    translated. One bad item/language never aborts the whole run."""
+    summary: dict[str, dict[str, int]] = {rt: {lang: 0 for lang in languages} for rt in ref_types}
+
+    for ref_type in ref_types:
+        pc_index = pc_client.Index(_index_name_for_ref_type(ref_type))
+        for item_id, metadata in _iter_source_items(pc_index, limit=limit):
+            text = _extract_text_for_ref_type(ref_type, metadata)
+            if not text:
+                continue
+
+            for language in languages:
+                try:
+                    summary[ref_type][language] += 1
+                    if dry_run:
+                        continue
+                    translated = translate_text(
+                        translation_client, model=model_name, text=text, language=language
+                    )
+                    upsert_translation(
+                        session_factory,
+                        ref_type=ref_type,
+                        ref_key=item_id,
+                        language=language,
+                        translated_text=translated,
+                        model_name=model_name,
+                    )
+                except Exception:
+                    logger.error(
+                        "Failed to translate/upsert item_id=%s ref_type=%s language=%s",
+                        item_id,
+                        ref_type,
+                        language,
+                        exc_info=True,
+                    )
+
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    languages = [lang.strip().lower() for lang in args.languages.split(",") if lang.strip()]
+    ref_types = REF_TYPE_CHOICES if args.ref_type == "all" else [args.ref_type]
+
+    translation_client = None if args.dry_run else _get_translation_client()
+    pc_client = Pinecone(api_key=PINECONE_API_KEY)
+
+    summary = run_batch(
+        languages=languages,
+        ref_types=ref_types,
+        limit=args.limit,
+        dry_run=args.dry_run,
+        model_name=args.model,
+        translation_client=translation_client,
+        pc_client=pc_client,
+        session_factory=SessionLocal,
+    )
+    logger.info("Batch complete: %s", summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/reference_translation_service.py
+++ b/services/reference_translation_service.py
@@ -1,0 +1,62 @@
+"""Join-after-retrieval translation lookup for DEE-67.
+
+This is a Postgres sidecar lookup (`reference_translations` table), NOT a Pinecone
+metadata field -- see CONTEXT.md for the storage decision (40 KB/vector Pinecone
+metadata limit ruled out storing translations directly on vectors). Retrieval/ranking
+is completely untouched; this service is called AFTER retrieval, from the formatter
+layer in `core/utils.py`, to merge selected-language translation text onto the
+already-formatted reference dicts.
+
+`alookup_translations` has no FastAPI `Depends()` call site -- it's invoked both from
+a route function (via `core/pipeline.py`) and from a plain async generator
+(`core/pipeline_langgraph.py`), so it opens and closes its own short-lived
+`AsyncSessionLocal()` context manager per call rather than accepting an injected
+session.
+"""
+import logging
+from typing import Iterable
+
+from sqlalchemy import select
+
+from db.async_session import AsyncSessionLocal
+from db.models.reference_translations import ReferenceTranslation
+
+logger = logging.getLogger(__name__)
+
+
+async def alookup_translations(ref_type: str, ref_keys: Iterable[str], language: str) -> dict[str, str]:
+    """Look up translated text for a batch of reference keys.
+
+    Args:
+        ref_type: One of "hadith", "quran_translation", "tafsir_text".
+        ref_keys: Iterable of reference keys (hadith_id or Pinecone chunk_id).
+        language: Target language (lowercase canonical string, e.g. "urdu").
+
+    Returns:
+        dict mapping ref_key -> translated_text for rows that exist. Missing keys
+        are simply absent from the dict (callers fall back to None). Always returns
+        a dict -- never raises -- so a DB error never breaks the surrounding
+        request/response flow.
+    """
+    keys = sorted({str(k) for k in ref_keys if k not in (None, "", "N/A")})
+    if not keys:
+        return {}
+
+    try:
+        async with AsyncSessionLocal() as db:
+            stmt = select(ReferenceTranslation).where(
+                ReferenceTranslation.ref_type == ref_type,
+                ReferenceTranslation.ref_key.in_(keys),
+                ReferenceTranslation.language == language,
+            )
+            result = await db.execute(stmt)
+            rows = result.scalars().all()
+            return {row.ref_key: row.translated_text for row in rows}
+    except Exception:
+        logger.error(
+            "alookup_translations failed for ref_type=%s language=%s",
+            ref_type,
+            language,
+            exc_info=True,
+        )
+        return {}

--- a/tests/test_reference_translations.py
+++ b/tests/test_reference_translations.py
@@ -1,0 +1,282 @@
+"""
+DEE-67 reference-translation tests.
+
+Deterministic unit tests (mocked, no network/DB) proving:
+  - `services.reference_translation_service.alookup_translations` opens its own
+    AsyncSessionLocal, queries by (ref_type, ref_key IN (...), language), and always
+    returns a dict (never raises, even on DB error).
+  - `core.utils.aformat_references_as_json` / `aformat_quran_references_as_json` skip
+    the DB call entirely when no non-English language is selected, and otherwise merge
+    translations onto the existing base formatter output without touching existing
+    fields.
+  - `core.pipeline.references_pipeline` threads `language` through to the async
+    formatter.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeRow:
+    def __init__(self, ref_key: str, translated_text: str):
+        self.ref_key = ref_key
+        self.translated_text = translated_text
+
+
+class _FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalars(self._rows)
+
+
+class _FakeAsyncSession:
+    """Fake async-context-manager AsyncSession stub. `execute` is an AsyncMock so
+    callers can configure return_value or side_effect per test."""
+
+    def __init__(self, rows=None, raise_exc=None):
+        self._rows = rows or []
+        self._raise_exc = raise_exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, stmt):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return _FakeResult(self._rows)
+
+
+def _make_session_factory(rows=None, raise_exc=None):
+    def factory():
+        return _FakeAsyncSession(rows=rows, raise_exc=raise_exc)
+    return factory
+
+
+class TestAlookupTranslations:
+    @pytest.mark.asyncio
+    async def test_returns_dict_when_rows_exist(self):
+        from services import reference_translation_service
+
+        rows = [_FakeRow("h1", "translated h1"), _FakeRow("h2", "translated h2")]
+        with patch.object(
+            reference_translation_service,
+            "AsyncSessionLocal",
+            _make_session_factory(rows=rows),
+        ):
+            result = await reference_translation_service.alookup_translations(
+                "hadith", ["h1", "h2"], "urdu"
+            )
+
+        assert result == {"h1": "translated h1", "h2": "translated h2"}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_on_db_exception(self):
+        from services import reference_translation_service
+
+        with patch.object(
+            reference_translation_service,
+            "AsyncSessionLocal",
+            _make_session_factory(raise_exc=RuntimeError("db down")),
+        ):
+            result = await reference_translation_service.alookup_translations(
+                "hadith", ["h1"], "urdu"
+            )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_for_empty_ref_keys(self):
+        from services import reference_translation_service
+
+        # AsyncSessionLocal should never even be opened for empty input.
+        with patch.object(
+            reference_translation_service,
+            "AsyncSessionLocal",
+            _make_session_factory(rows=[_FakeRow("h1", "should not be reached")]),
+        ) as mocked_factory:
+            result = await reference_translation_service.alookup_translations(
+                "hadith", [], "urdu"
+            )
+
+        assert result == {}
+
+
+class TestAformatReferencesAsJson:
+    def _base_docs(self):
+        return [
+            {
+                "metadata": {"hadith_id": "h1", "sect": "shia"},
+                "page_content_en": "text one",
+                "page_content_ar": "arabic one",
+            },
+            {
+                "metadata": {"hadith_id": "h2", "sect": "shia"},
+                "page_content_en": "text two",
+                "page_content_ar": "arabic two",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_language_none_skips_db_call(self):
+        from core import utils
+
+        docs = self._base_docs()
+        with patch(
+            "core.utils.reference_translation_service.alookup_translations",
+            new=AsyncMock(),
+        ) as mocked_lookup:
+            result = await utils.aformat_references_as_json(docs, language=None)
+
+        mocked_lookup.assert_not_called()
+        assert len(result) == 2
+        for ref in result:
+            assert ref["text_translated"] is None
+            assert ref["translated_language"] is None
+        # existing fields unchanged
+        assert result[0]["text"] == "text one"
+        assert result[0]["text_ar"] == "arabic one"
+
+    @pytest.mark.asyncio
+    async def test_language_english_skips_db_call(self):
+        from core import utils
+
+        docs = self._base_docs()
+        with patch(
+            "core.utils.reference_translation_service.alookup_translations",
+            new=AsyncMock(),
+        ) as mocked_lookup:
+            result = await utils.aformat_references_as_json(docs, language="english")
+
+        mocked_lookup.assert_not_called()
+        for ref in result:
+            assert ref["text_translated"] is None
+            assert ref["translated_language"] is None
+
+    @pytest.mark.asyncio
+    async def test_language_urdu_calls_lookup_once_and_merges(self):
+        from core import utils
+
+        docs = self._base_docs()
+        with patch(
+            "core.utils.reference_translation_service.alookup_translations",
+            new=AsyncMock(return_value={"h1": "translated h1"}),
+        ) as mocked_lookup:
+            result = await utils.aformat_references_as_json(docs, language="urdu")
+
+        mocked_lookup.assert_called_once_with("hadith", ["h1", "h2"], "urdu")
+        assert result[0]["text_translated"] == "translated h1"
+        assert result[0]["translated_language"] == "urdu"
+        # no matching translation row -> fallback to None
+        assert result[1]["text_translated"] is None
+        assert result[1]["translated_language"] == "urdu"
+        # existing fields still unchanged
+        assert result[0]["text"] == "text one"
+        assert result[1]["text_ar"] == "arabic two"
+
+
+class TestAformatQuranReferencesAsJson:
+    def _base_docs(self):
+        return [
+            {
+                "chunk_id": "c1",
+                "metadata": {"surah_name": "Al-Fatiha"},
+                "quran_translation": "verse one",
+                "page_content_en": "tafsir one",
+            },
+            {
+                "chunk_id": "c2",
+                "metadata": {"surah_name": "Al-Baqarah"},
+                "quran_translation": "verse two",
+                "page_content_en": "tafsir two",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_language_none_skips_db_call(self):
+        from core import utils
+
+        docs = self._base_docs()
+        with patch(
+            "core.utils.reference_translation_service.alookup_translations",
+            new=AsyncMock(),
+        ) as mocked_lookup:
+            result = await utils.aformat_quran_references_as_json(docs, language=None)
+
+        mocked_lookup.assert_not_called()
+        for ref in result:
+            assert ref["quran_translation_translated"] is None
+            assert ref["tafsir_text_translated"] is None
+            assert ref["translated_language"] is None
+        assert result[0]["quran_translation"] == "verse one"
+        assert result[0]["tafsir_text"] == "tafsir one"
+
+    @pytest.mark.asyncio
+    async def test_language_urdu_calls_lookup_twice_and_merges(self):
+        from core import utils
+
+        docs = self._base_docs()
+
+        async def fake_lookup(ref_type, ref_keys, language):
+            if ref_type == "quran_translation":
+                return {"c1": "translated verse one"}
+            if ref_type == "tafsir_text":
+                return {"c2": "translated tafsir two"}
+            return {}
+
+        with patch(
+            "core.utils.reference_translation_service.alookup_translations",
+            new=AsyncMock(side_effect=fake_lookup),
+        ) as mocked_lookup:
+            result = await utils.aformat_quran_references_as_json(docs, language="urdu")
+
+        assert mocked_lookup.call_count == 2
+        call_ref_types = {call.args[0] for call in mocked_lookup.call_args_list}
+        assert call_ref_types == {"quran_translation", "tafsir_text"}
+
+        assert result[0]["quran_translation_translated"] == "translated verse one"
+        assert result[0]["tafsir_text_translated"] is None
+        assert result[1]["quran_translation_translated"] is None
+        assert result[1]["tafsir_text_translated"] == "translated tafsir two"
+        for ref in result:
+            assert ref["translated_language"] == "urdu"
+        # existing fields unchanged
+        assert result[0]["quran_translation"] == "verse one"
+        assert result[1]["tafsir_text"] == "tafsir two"
+
+
+class TestReferencesPipelineLanguageThreading:
+    @pytest.mark.asyncio
+    async def test_language_reaches_formatter(self):
+        from core import pipeline
+
+        with patch(
+            "core.pipeline.classifier.aclassify_non_islamic_query",
+            new=AsyncMock(return_value=False),
+        ), patch(
+            "core.pipeline.enhancer.aenhance_query",
+            new=AsyncMock(return_value="enhanced query"),
+        ), patch(
+            "core.pipeline.retriever.aretrieve_shia_documents",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "core.pipeline.utils.aformat_references_as_json",
+            new=AsyncMock(return_value=[]),
+        ) as mocked_formatter:
+            await pipeline.references_pipeline("test query", "shia", 10, language="urdu")
+
+        mocked_formatter.assert_called_once_with([], "urdu")

--- a/tests/test_translate_references.py
+++ b/tests/test_translate_references.py
@@ -1,0 +1,262 @@
+"""
+DEE-67 batch MT script tests.
+
+Deterministic unit tests (mocked, no network/DB) for scripts/translate_references.py:
+CLI parsing, translate_text(), _get_translation_client() key isolation, dry-run safety
+(never calls Anthropic/DB), --limit sampling, and upsert_translation()'s idempotent
+merge/commit shape.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+
+from core.utils import compress_text
+from scripts.translate_references import (
+    DEFAULT_MODEL,
+    SUPPORTED_LANGUAGES,
+    _get_translation_client,
+    parse_args,
+    run_batch,
+    translate_text,
+    upsert_translation,
+)
+
+
+# ================================================================
+# parse_args
+# ================================================================
+
+class TestParseArgs:
+    def test_defaults(self):
+        args = parse_args([])
+        assert args.languages == ",".join(SUPPORTED_LANGUAGES)
+        assert args.ref_type == "all"
+        assert args.dry_run is False
+        assert args.model == DEFAULT_MODEL
+        assert args.limit is None
+
+
+# ================================================================
+# _get_translation_client
+# ================================================================
+
+class TestGetTranslationClient:
+    def test_raises_when_env_var_unset(self, monkeypatch):
+        monkeypatch.delenv("TRANSLATION_ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="TRANSLATION_ANTHROPIC_API_KEY"):
+            _get_translation_client()
+
+    def test_constructs_client_with_dedicated_key(self, monkeypatch):
+        monkeypatch.setenv("TRANSLATION_ANTHROPIC_API_KEY", "sk-ant-personal-test-key")
+        with patch("scripts.translate_references.Anthropic") as mocked_anthropic_cls:
+            mocked_anthropic_cls.return_value = MagicMock()
+            client = _get_translation_client()
+
+        mocked_anthropic_cls.assert_called_once_with(api_key="sk-ant-personal-test-key")
+        assert client is mocked_anthropic_cls.return_value
+
+
+# ================================================================
+# translate_text
+# ================================================================
+
+class TestTranslateText:
+    def test_calls_messages_create_and_returns_stripped_text(self):
+        fake_client = MagicMock()
+        fake_client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="  translated output  ")]
+        )
+
+        result = translate_text(
+            fake_client, model="claude-sonnet-5", text="source text", language="urdu"
+        )
+
+        assert result == "translated output"
+        fake_client.messages.create.assert_called_once()
+        _, kwargs = fake_client.messages.create.call_args
+        assert kwargs["model"] == "claude-sonnet-5"
+        assert "urdu" in kwargs["system"]
+        assert kwargs["messages"] == [{"role": "user", "content": "source text"}]
+        assert kwargs["max_tokens"] > 0
+
+
+# ================================================================
+# upsert_translation
+# ================================================================
+
+class _FakeSession:
+    def __init__(self, recorder: dict):
+        self._recorder = recorder
+
+    def merge(self, row):
+        self._recorder["merged_row"] = row
+
+    def commit(self):
+        self._recorder["committed"] = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestUpsertTranslation:
+    def test_constructs_row_and_merges_commits(self):
+        recorder: dict = {}
+
+        def session_factory():
+            return _FakeSession(recorder)
+
+        upsert_translation(
+            session_factory,
+            ref_type="hadith",
+            ref_key="h1",
+            language="urdu",
+            translated_text="translated text",
+            model_name="claude-sonnet-5",
+        )
+
+        assert recorder.get("committed") is True
+        row = recorder["merged_row"]
+        assert row.ref_type == "hadith"
+        assert row.ref_key == "h1"
+        assert isinstance(row.ref_key, str)
+        assert row.language == "urdu"
+        assert row.translated_text == "translated text"
+        assert row.source == "mt"
+        assert row.model == "claude-sonnet-5"
+        assert row.translated_at.tzinfo is not None
+        assert row.translated_at <= datetime.now(timezone.utc)
+
+
+# ================================================================
+# run_batch
+# ================================================================
+
+class _FakeVector:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+
+class _FakeFetchResponse:
+    def __init__(self, vectors: dict):
+        self.vectors = vectors
+
+
+class _FakePineconeIndex:
+    """Fake Pinecone index: `.list()` yields pages of id lists, `.fetch()` returns
+    a response object with `.vectors` mapping id -> object with `.metadata`."""
+
+    def __init__(self, items: dict[str, dict], page_size: int = 2):
+        self._items = items
+        self._page_size = page_size
+
+    def list(self, namespace=None):
+        ids = list(self._items.keys())
+        for i in range(0, len(ids), self._page_size):
+            yield ids[i : i + self._page_size]
+
+    def fetch(self, ids, namespace=None):
+        vectors = {vid: _FakeVector(self._items[vid]) for vid in ids}
+        return _FakeFetchResponse(vectors)
+
+
+class _FakePineconeClient:
+    def __init__(self, index: _FakePineconeIndex):
+        self._index = index
+
+    def Index(self, name):
+        return self._index
+
+
+def _make_hadith_items(n: int) -> dict:
+    return {
+        f"h{i}": {"text_en": compress_text(f"hadith text {i}")}
+        for i in range(n)
+    }
+
+
+class TestRunBatchDryRun:
+    def test_dry_run_never_calls_translate_or_upsert(self):
+        items = _make_hadith_items(3)
+        pc_client = _FakePineconeClient(_FakePineconeIndex(items))
+        languages = ["urdu", "farsi"]
+
+        with patch("scripts.translate_references.translate_text") as mocked_translate, patch(
+            "scripts.translate_references.upsert_translation"
+        ) as mocked_upsert:
+            summary = run_batch(
+                languages=languages,
+                ref_types=["hadith"],
+                limit=None,
+                dry_run=True,
+                model_name="claude-sonnet-5",
+                translation_client=None,
+                pc_client=pc_client,
+                session_factory=MagicMock(),
+            )
+
+        mocked_translate.assert_not_called()
+        mocked_upsert.assert_not_called()
+        assert summary == {"hadith": {"urdu": 3, "farsi": 3}}
+
+    def test_limit_caps_items_processed(self):
+        items = _make_hadith_items(5)
+        pc_client = _FakePineconeClient(_FakePineconeIndex(items))
+        languages = ["urdu"]
+
+        with patch("scripts.translate_references.translate_text") as mocked_translate, patch(
+            "scripts.translate_references.upsert_translation"
+        ) as mocked_upsert:
+            summary = run_batch(
+                languages=languages,
+                ref_types=["hadith"],
+                limit=1,
+                dry_run=True,
+                model_name="claude-sonnet-5",
+                translation_client=None,
+                pc_client=pc_client,
+                session_factory=MagicMock(),
+            )
+
+        mocked_translate.assert_not_called()
+        mocked_upsert.assert_not_called()
+        assert summary == {"hadith": {"urdu": 1}}
+
+    def test_live_path_calls_translate_and_upsert_per_item_language(self):
+        items = _make_hadith_items(2)
+        pc_client = _FakePineconeClient(_FakePineconeIndex(items))
+        languages = ["urdu", "farsi"]
+        fake_client = MagicMock()
+
+        with patch(
+            "scripts.translate_references.translate_text", return_value="translated"
+        ) as mocked_translate, patch(
+            "scripts.translate_references.upsert_translation"
+        ) as mocked_upsert:
+            summary = run_batch(
+                languages=languages,
+                ref_types=["hadith"],
+                limit=None,
+                dry_run=False,
+                model_name="claude-sonnet-5",
+                translation_client=fake_client,
+                pc_client=pc_client,
+                session_factory=MagicMock(),
+            )
+
+        assert summary == {"hadith": {"urdu": 2, "farsi": 2}}
+        # 2 items x 2 languages = 4 calls each
+        assert mocked_translate.call_count == 4
+        assert mocked_upsert.call_count == 4


### PR DESCRIPTION
## Purpose

Closes DEE-67 (reference-lookup slice of DEE-63 multilingual support).

References today come back only in English + Arabic. This adds the user's **selected-language** translation alongside them, without touching the retrieval/vector path — translations live in a Postgres sidecar table and are joined in *after* retrieval by the reference IDs already in the Pinecone metadata.

## What changed

- **New sidecar table `reference_translations`** (`db/models/reference_translations.py` + migration `reference_translations_001`). Composite PK `(ref_type, ref_key, language)` so one table covers hadith (`ref_key = hadith_id`) and Quran/tafsir (`ref_key = chunk_id`). Columns: `translated_text`, provenance (`source` default `mt`, `translated_at`, `model`), and a nullable `reviewed_at` hedge. Deliberately **not** a per-row status/reviewer state machine — per the mentor's "MT ships, sample-review in dev before go-live" decision.
- **Join-after-retrieval enrichment** (`services/reference_translation_service.py` + async formatter wrappers in `core/utils.py`). The existing `text`/`text_ar` fields are untouched; new fields are added alongside: `text_translated` + `translated_language` for hadith, `quran_translation_translated` + `tafsir_text_translated` for Quran/tafsir. When no translation row exists (or language is english/unset), the new fields are `null` and clients keep the EN/AR content — clean fallback, no errors.
- **Language input:** `POST /references` gains an optional `language` query param (mirroring the existing `sect`/`limit` params). On the streaming chat path, the `hadith_references`/`quran_references` SSE events reuse the `target_language` already in `ChatState`.
- **Offline batch MT script** (`scripts/translate_references.py`) that can translate the entire reference corpus × 6 languages and upsert into the table. It uses a **dedicated** `TRANSLATION_ANTHROPIC_API_KEY` + `claude-sonnet-5` via the raw `anthropic` SDK — it never imports `core.chat_models` or the app's `ANTHROPIC_API_KEY`, so translation cost stays isolated on a personal key. Built and unit-tested, but **not run** in this PR (population is a separate ops step). Run commands are documented in `CLAUDE.md`.

## Impacted endpoints

- `GET/POST /references` — new optional `language` query param; response now carries the selected-language fields alongside EN/AR.
- `POST /chat/stream/agentic` and `POST /chat/agentic` — the `hadith_references` / `quran_references` SSE events now include the selected-language translation (via the existing `target_language`). Additive; existing fields unchanged.

## Migrations

**Yes — one new migration:** `reference_translations_001` (chains onto current head `onboarding_profiles_001`). Needs `alembic upgrade head` at deploy time.

I validated it **offline** (no DB) with `alembic upgrade onboarding_profiles_001:head --sql`, which emits a clean transactional `CREATE TABLE reference_translations (...)` with the composite PK and nullable `reviewed_at` as intended. I did **not** apply it to the live database — the shared Supabase host wasn't resolvable from my local Docker (project paused / IPv4-vs-pooler DNS), which is an environment issue, not a migration problem. It applies at deploy.

## Env var changes

- **New:** `TRANSLATION_ANTHROPIC_API_KEY` — used **only** by the offline `scripts/translate_references.py` batch job, not by the running app. The deployed API needs no new env var. Documented in `CLAUDE.md`.

## Testing evidence

- **Deterministic unit tests: 17 passed** (`tests/test_reference_translations.py` 9 + `tests/test_translate_references.py` 8) — mocked, no DB/Pinecone/live-LLM. Confirmed green in Docker via `docker compose run --rm -e REDIS_URL=redis://127.0.0.1:1/0 api pytest tests/test_reference_translations.py tests/test_translate_references.py -q`.
- **Migration validated offline** (see Migrations above) — DDL generated and eyeballed; correct.
- **Full suite:** 303 passed, 15 failed — the 15 failures were confirmed **identical on the pre-change base commit** (`76fd1fe`) via a comparison checkout, so they're pre-existing (the DEE-4x async-migration test drift: `test_agentic_streaming_pipeline.py`, `test_agentic_streaming_sse.py`, `test_async_concurrency_full.py`, `test_chat_agent_async.py`, `test_fiqh_integration.py`, `test_primer_service.py`). Not touched by this PR.
- **Not run:** the batch MT job (build-only by design; needs a personal key + live services) and the live migration apply (DB unreachable locally, applies at deploy).

## Trade-offs

- When a non-English `language` is requested, the reference path does one extra keyed Postgres lookup (`(ref_type, ref_key, language) IN ...`) to attach translations. It's short-circuited entirely for english/unset, so the default path is unchanged. Minor added latency on the references path only.
- Until the batch job populates the corpus, non-English references simply fall back to EN/AR — the feature is wired end-to-end but shows translations only for rows that have been translated.

## Notes

Sibling DEE-63 slices are separate: DEE-68 (chatbot response quality) is a separate PR; DEE-69 (hikmah lesson i18n) will reuse this sidecar + provenance pattern.
