### PR TITLE
fix(DEE-60): summary first-need gap, no-tables prompts, deploy completeness (DEE-36/DEE-59)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -82,15 +82,21 @@ jobs:
             docker compose build
           fi
 
+      - name: Run database migrations
+        # Runs alembic in a throwaway container from the freshly built image
+        # BEFORE the new app version starts serving — new code must never race
+        # a missing table (e.g. DEE-67's reference_translations).
+        run: docker compose run --rm api alembic upgrade head
+
       - name: Restart service
         run: |
           docker compose down
           docker compose up -d
 
       - name: Wait for /health (60s budget)
-        # Polls the in-container health endpoint via the host's loopback
-        # because docker-compose.yml maps :8000 (Caddy fronts HTTPS but is
-        # in a separate container). 30 attempts × 2s = 60s budget covers
+        # Polls the health endpoint via the host loopback — docker-compose.yml
+        # publishes 127.0.0.1:8000:8000 (loopback-only; Caddy fronts public
+        # HTTPS in its own container). 30 attempts × 2s = 60s budget covers
         # cold-start of the sentence-transformers model.
         run: |
           for i in $(seq 1 30); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ USER appuser
 # Expose internal app port
 EXPOSE 8000
 
-# Start Gunicorn with Uvicorn workers
-# Replace "app.main:app" with your module:app path
+# Start Gunicorn with Uvicorn workers (async ASGI — required by the DEE-36
+# end-to-end async pipeline; plain sync gunicorn workers would break it).
+# DEE-59: `-w 2` is load-bearing for the DB connection budget — each worker
+# opens sync (2+1) + async (2+1) = 6 pooled connections; 2 workers = 12 of the
+# 15-client Supabase session-mode cap. Recompute db/session.py +
+# db/async_session.py pool sizes BEFORE changing the worker count.
 CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "2", "-b", "0.0.0.0:8000", "main:app"]

--- a/README.md
+++ b/README.md
@@ -486,19 +486,36 @@ cd ~/deen-backend
 # 3. Pull latest code
 git pull
 
-# 4. Rebuild and restart containers
+# 4. Rebuild
 docker compose down
 docker compose build --no-cache
+
+# 5. Run database migrations BEFORE starting the new version — new code must
+#    never race a missing table (e.g. DEE-67's reference_translations)
+docker compose run --rm api alembic upgrade head
+
+# 6. Start
 docker compose up -d
 
-# 5. Run database migrations (if any new ones)
-docker exec -it deen-backend alembic upgrade head
-
-# 6. Verify deployment
+# 7. Verify deployment
 docker ps                                              # containers running?
 docker logs --tail=50 deen-backend                     # no startup errors?
-curl https://api.thedeenfoundation.com/health          # responding?
+curl http://127.0.0.1:8000/health                      # container healthy (loopback publish)?
+curl https://api.thedeenfoundation.com/health          # responding via Caddy?
 ```
+
+**Connection-budget invariant (DEE-59):** the Dockerfile's gunicorn `-w 2` is
+coupled to the SQLAlchemy pool caps — per worker, sync (2+1) + async (2+1) = 6
+pooled connections, so 2 workers = 12 of the 15-client Supabase session-mode
+cap. If you change the worker count, recompute the pool sizes in
+`db/session.py` and `db/async_session.py` first, or production will hit
+`EMAXCONNSESSION` pooler-exhaustion errors again.
+
+**Feature rollback (DEE-60 kill switches):** the token-cost phases can each be
+reverted without a redeploy by adding the matching flag to `.env` with value
+`0` (`TOOLMSG_COMPACT`, `HISTORY_BUDGETS`, `AGENT_CACHE_V2`,
+`FIQH_V2_RETRIEVAL`, `HISTORY_SUMMARY`) and recreating the container
+(see below — `restart` alone will not pick up `.env` changes).
 
 ### Quick Reference Commands
 
@@ -508,7 +525,11 @@ docker logs -f deen-backend              # follow live logs
 docker logs --tail=200 deen-backend      # last 200 lines
 docker logs --tail=100 deen-caddy        # Caddy/TLS logs
 
-# Restart without rebuilding (e.g. .env change only)
+# Apply a .env change without rebuilding — the container must be RECREATED;
+# `docker compose restart` reuses the old environment and will NOT pick it up
+docker compose up -d --force-recreate api
+
+# Restart without rebuilding (process bounce only — does NOT re-read .env)
 docker compose restart
 
 # Full clean rebuild (if disk is tight)

--- a/core/history_budget.py
+++ b/core/history_budget.py
@@ -19,7 +19,11 @@ from langchain_core.messages import AIMessage, BaseMessage
 
 # Per-call-site budgets: (max_messages, max_total_chars). Central so tuning
 # happens in one place; validated by the token bench's multi-turn slice.
-GENERATION_BUDGET = (10, 8000)
+# GENERATION char cap raised 8000 -> 12000 after live testing: answers run
+# 5-11k chars, so 8000 collapsed the window to ~1 message and made the
+# summary carry nearly all context. 12000 keeps ~2 recent turns verbatim;
+# with AGENT_CACHE_V2 the extra history reads at the 0.1x cached rate.
+GENERATION_BUDGET = (10, 12000)
 AGENT_BUDGET = (10, 8000)
 ENHANCER_BUDGET = (6, 4000)
 CLASSIFIER_MAX_MESSAGES = 4

--- a/core/prompt_templates.py
+++ b/core/prompt_templates.py
@@ -41,7 +41,8 @@ Your primary objectives:
 
 Formatting:
 - Use clear markdown: headings, paragraphs, bullet points. IMPORTANT: always add an extra blank line between paragraphs for readability.
-- Avoid tables unless absolutely necessary.
+- Never format content as a markdown table — tables do not render in the app. Use headings, bullet points, or numbered lists instead.
+- Keep answers focused: aim for roughly 300-600 words unless the question genuinely requires more depth. Depth should come from the quality of evidence, not from length.
 - References may have missing metadata fields — ignore those, but include as much citation detail as is available so the reference can be identified and validated.
 
 Example citations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       - .env
     expose:
       - "8000"
+    # Loopback-only publish so the host (deploy workflow health gate, box-local
+    # curl) can reach /health directly. NOT internet-exposed — Caddy remains
+    # the public entrypoint on :80/:443.
+    ports:
+      - "127.0.0.1:8000:8000"
     restart: unless-stopped
 
   caddy:

--- a/modules/fiqh/generator.py
+++ b/modules/fiqh/generator.py
@@ -42,7 +42,8 @@ STRICT RULES:
 - You MUST use at least one [n] citation in your response
 - Write in a clear, respectful tone appropriate for a religious legal question
 - Do NOT issue fatwas — present what Sistani's published rulings state
-- Do NOT speculate beyond what the evidence states"""
+- Do NOT speculate beyond what the evidence states
+- Never format content as a markdown table — tables do not render in the app; use headings and numbered lists instead"""
 
 def _build_messages(query: str, evidence: str) -> list:
     return [

--- a/services/summary_service.py
+++ b/services/summary_service.py
@@ -92,10 +92,15 @@ async def refresh_session_summary(session_id: str) -> None:
         # REDIS_MAX_MESSAGES the length is constant (a length-modulo gate
         # would then fire every turn — review finding 1), and odd-length
         # histories after a failed stream would never fire (finding 2).
+        # Exception: when no summary exists yet, write one immediately — the
+        # first crossing lands on an odd count, and skipping it leaves the very
+        # next turn reading budget-truncated history with no summary at all
+        # (live finding: turn 7 of a 7-turn chat denied knowing turn 1).
         client = memory._get_async_redis()
         turn_count = await client.incr(_turn_counter_key(session_id))
         await client.expire(_turn_counter_key(session_id), memory.TTL_SECONDS)
-        if turn_count % 2 != 0:
+        has_summary = await client.exists(_summary_key(session_id))
+        if has_summary and turn_count % 2 != 0:
             return
 
         older = messages[:-SUMMARY_KEEP_RECENT]

--- a/tests/test_token_phase5.py
+++ b/tests/test_token_phase5.py
@@ -39,6 +39,9 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
+    async def exists(self, key):
+        return 1 if key in self.store else 0
+
 
 class _FakeHistory:
     def __init__(self, messages):
@@ -100,17 +103,31 @@ def test_refresh_summarizes_older_turns_and_stores(monkeypatch):
 def test_refresh_cadence_every_second_turn_even_at_history_cap(monkeypatch):
     """The cadence gate uses a Redis turn counter, NOT history length — at the
     30-message trim cap the length is constant, and a length-modulo gate would
-    degenerate to refreshing every turn (review finding 1)."""
+    degenerate to refreshing every turn (review finding 1). The FIRST crossing
+    writes immediately regardless of parity (first-need fix); after that the
+    every-second-turn cadence applies."""
     monkeypatch.delenv("HISTORY_SUMMARY", raising=False)
     fake_redis, calls = _patch_env(monkeypatch, _turns(15))  # 30 msgs == the cap
-    _run(summary_service.refresh_session_summary("s1"))  # turn 1 -> skip
-    assert calls == []
-    _run(summary_service.refresh_session_summary("s1"))  # turn 2 -> refresh
+    _run(summary_service.refresh_session_summary("s1"))  # turn 1, no summary yet -> write now
     assert len(calls) == 1
-    _run(summary_service.refresh_session_summary("s1"))  # turn 3 -> skip
-    assert len(calls) == 1
-    _run(summary_service.refresh_session_summary("s1"))  # turn 4 -> refresh
+    _run(summary_service.refresh_session_summary("s1"))  # turn 2 (even) -> refresh
     assert len(calls) == 2
+    _run(summary_service.refresh_session_summary("s1"))  # turn 3 (odd, summary exists) -> skip
+    assert len(calls) == 2
+    _run(summary_service.refresh_session_summary("s1"))  # turn 4 (even) -> refresh
+    assert len(calls) == 3
+
+
+def test_first_crossing_writes_summary_immediately(monkeypatch):
+    """Regression for the live first-need gap: history first exceeds the
+    trigger after turn 6 (12 msgs, counter=1, odd). The old parity-only gate
+    skipped it, so turn 7 read budget-truncated history with NO summary and
+    denied knowing turn 1. The first crossing must write the summary now."""
+    monkeypatch.delenv("HISTORY_SUMMARY", raising=False)
+    fake_redis, calls = _patch_env(monkeypatch, _turns(6))  # 12 msgs > trigger
+    _run(summary_service.refresh_session_summary("s1"))
+    assert len(calls) == 1
+    assert summary_service._summary_key("s1") in fake_redis.store
 
 
 def test_kill_switch_disables_everything(monkeypatch):


### PR DESCRIPTION
# Follow-up fixes from live release-candidate testing (DEE-60) + deploy completeness (DEE-36/DEE-59)

Found during live multi-turn testing of the release candidate (PR #110). Two commits:

## 1. `fix(DEE-60)` — summary first-need gap, no-tables rules, length/budget tune

- **Bug — summary arrived one turn too late**: the every-2nd-turn refresh cadence skipped the *first* threshold crossing (odd counter), so the first budget-truncated turn read history with **no summary at all**. Live repro: turn 7 of a 7-turn chat answered *"I do not have any record of a previous conversation."* Fix: write immediately when no summary exists; parity cadence governs refreshes only. Regression test added (`test_first_crossing_writes_summary_immediately`).
- **Markdown tables don't render in the app UI**: general generator's soft "avoid tables" is now a hard rule; the fiqh generator (which had **no** tables rule) gained the same. Verified live with comparison table-bait questions on both paths — headings/lists only.
- **Answer length**: soft 300–600-word focus guideline added (live answers ran 1,200–1,600 words, one streamed 253s). Post-change smoke: 359 and 712 words, quality intact. `GENERATION_BUDGET` chars 8000 → 12000 so ~2 recent turns stay verbatim (at current answer lengths 8000 collapsed to ~1 message, making the summary carry nearly all context). With `AGENT_CACHE_V2` the extra history reads at the 0.1× cached rate.

## 2. `chore(deploy)` — DEE-36/DEE-59 deployment steps and scripts completeness

- **`deploy-dev.yml`: adds the missing `alembic upgrade head` step** (throwaway container, before restart) — the workflow never ran migrations; DEE-67's `reference_translations` table would have raced new code.
- **`docker-compose.yml`: loopback-only publish `127.0.0.1:8000:8000`** — the workflow's `/health` gate polled host :8000 but the port was only `expose`d, so the gate could never pass. Caddy remains the sole public entrypoint.
- **`Dockerfile`**: documents that `-w 2` is load-bearing for the DEE-59 connection budget (6 pooled conns/worker → 12 < 15 Supabase session cap) and that `UvicornWorker` is required by the DEE-36 async pipeline.
- **README runbook**: migrations moved *before* `up -d`; fixed the `.env`-change trap (`docker compose restart` does **not** re-read `env_file` — use `up -d --force-recreate`); added the DEE-59 budget invariant and DEE-60 kill-switch rollback procedure.

## Test evidence

- Affected suites: 82 passed (phase 2/3/5, DEE-12, DEE-68, fiqh generator).
- Full suite: 363 passed; failures are a strict subset of the known pre-existing environmental set (no new failures).
- Live smoke on this code: table-bait questions produce no tables on general + fiqh paths; general answers 359/712 words; greeting path intact.

Same commits are merged into release PR #110 so both branches ship identical code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
