### PR TITLE
chore(deploy): gunicorn --timeout 180 (missed the PR #111 merge window)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,8 @@ EXPOSE 8000
 # opens sync (2+1) + async (2+1) = 6 pooled connections; 2 workers = 12 of the
 # 15-client Supabase session-mode cap. Recompute db/session.py +
 # db/async_session.py pool sizes BEFORE changing the worker count.
-CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "2", "-b", "0.0.0.0:8000", "main:app"]
+# --timeout 180 (DEE-36 follow-up): for async UvicornWorkers this is a
+# liveness-heartbeat window, not a per-request clock — long SSE streams are
+# safe either way; 180s stops brief event-loop stalls under load from being
+# misread as a wedged worker and killed mid-stream.
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "2", "--timeout", "180", "-b", "0.0.0.0:8000", "main:app"]


### PR DESCRIPTION
Single commit d18f403 - the DEE-36 deployment-tuning item 1 that was pushed to the branch just as PR #111 was being merged, so it missed the merge. Release PR #110 already carries it; this brings main back to parity.

For async UvicornWorkers the timeout is liveness-heartbeat headroom, not a per-request clock - long SSE streams were already safe; 180s prevents brief event-loop stalls under load from being misread as a wedged worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)