### PR TITLE
fix(primers): release DB session before LLM work (pool starvation hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,8 +612,8 @@ This creates `api.thedeenfoundation.com → your server`. Caddy auto-provisions 
 
 ```bash
 docker compose build --no-cache
+docker compose run --rm api alembic upgrade head   # migrations BEFORE first start
 docker compose up -d
-docker exec -it deen-backend alembic upgrade head
 ```
 
 </details>

--- a/documentation/DEPLOYMENT.md
+++ b/documentation/DEPLOYMENT.md
@@ -258,7 +258,7 @@ docker logs --tail=200 deen-caddy
 
 ### Deployment Commands
 
-**Quick Reference** (also in README):
+**Quick Reference** (canonical copy in README — keep the two in sync):
 
 ```bash
 # Navigate to project
@@ -275,6 +275,12 @@ docker system prune -af
 
 # Rebuild with no cache
 docker compose build --no-cache
+
+# Run database migrations BEFORE starting the new version — new code must
+# never race a missing table (e.g. DEE-67's reference_translations).
+# Throwaway container from the freshly built image; no-op when there are
+# no new migrations.
+docker compose run --rm api alembic upgrade head
 
 # Start services
 docker compose up -d
@@ -331,18 +337,19 @@ DATABASE_URL=postgresql://user:password@rds-endpoint:5432/deen
 
 ### Running Migrations
 
+Migrations are part of every deploy (see Deployment Commands above) and must
+run **before** the new app version starts serving:
+
 ```bash
-# SSH into EC2
-ssh -i your-key.pem ubuntu@ec2-ip
+# Standard: throwaway container from the freshly built image
+docker compose run --rm api alembic upgrade head
+```
 
-# Enter backend container
-docker exec -it deen-backend bash
+To run them against an already-running container (ad-hoc, e.g. catching up
+after a deploy that skipped the step):
 
-# Run migrations
-alembic upgrade head
-
-# Exit container
-exit
+```bash
+docker exec -it deen-backend alembic upgrade head
 ```
 
 ### Database Backups

--- a/services/primer_service.py
+++ b/services/primer_service.py
@@ -790,6 +790,12 @@ class PrimerService:
 
         # Generate with LLM
         messages = primer_generation_messages(**prompt_inputs)
+        # All DB reads for this generation are done. Release the pooled
+        # connection before the long LLM call so concurrent primer requests
+        # don't starve the size-2+1 sync pool (same rule as the hikmah quiz
+        # memory path in services/hikmah_quiz_service.py). The session stays
+        # usable — _cache_primer re-acquires a connection for the short write.
+        self.db.close()
         # model = get_enhancer_model()
         # response = await model.ainvoke(messages)
         response = await primers_model.ainvoke(messages)
@@ -857,6 +863,12 @@ class PrimerService:
 
         # Generate with streaming LLM - stream tokens in real-time
         messages = primer_generation_messages(**prompt_inputs)
+        # All DB reads for this generation are done. Release the pooled
+        # connection before the LLM stream (tens of seconds) so concurrent
+        # primer streams don't pin the entire size-2+1 sync pool and starve
+        # other sync routes (hikmah trees, quiz-submit). The session stays
+        # usable — _cache_primer re-acquires a connection for the short write.
+        self.db.close()
         # model = get_enhancer_model()
 
         # Stream the response and send chunks immediately

--- a/tests/test_primer_service.py
+++ b/tests/test_primer_service.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, MagicMock, AsyncMock, patch
 from sqlalchemy.orm import Session
 
+import services.primer_service as primer_service_module
 from services.primer_service import PrimerService
 from db.models.lessons import Lesson
 from db.models.personalized_primers import PersonalizedPrimer
@@ -546,6 +547,64 @@ class TestFallbackResponse:
         assert response["from_cache"] is False
         assert response["stale"] is False
         assert response["personalized_available"] is False
+
+
+# Test: Pooled connection released before LLM work (Sentry PYTHON-FASTAPI-2E)
+class TestPoolReleaseBeforeLLM:
+    """The sync pool is capped at size 2 + overflow 1 per worker (DEE-59), so
+    holding a session across LLM generation (tens of seconds) starves every
+    other sync route. These tests pin the fix: the session must be closed
+    before the first LLM token is requested."""
+
+    @pytest.mark.asyncio
+    async def test_stream_releases_session_before_llm_stream(
+        self, primer_service, mock_db, sample_lesson, sample_user_signals
+    ):
+        """_stream_bullets_with_llm closes the session before consuming the LLM stream"""
+        closed_before_llm = {}
+
+        async def fake_astream(messages):
+            closed_before_llm["value"] = mock_db.close.called
+            chunk = Mock()
+            chunk.content = '{"personalized_bullets": ["Bullet 1", "Bullet 2"]}'
+            yield chunk
+
+        with patch.object(primer_service, "_fetch_lesson_content", return_value=[]):
+            with patch.object(primer_service_module, "primers_model") as mock_model:
+                mock_model.astream = fake_astream
+                events = [
+                    event
+                    async for event in primer_service._stream_bullets_with_llm(
+                        sample_lesson, sample_user_signals
+                    )
+                ]
+
+        assert closed_before_llm["value"] is True
+        bullet_events = [e for e in events if e["type"] == "bullet"]
+        assert [e["content"] for e in bullet_events] == ["Bullet 1", "Bullet 2"]
+
+    @pytest.mark.asyncio
+    async def test_generate_releases_session_before_llm_call(
+        self, primer_service, mock_db, sample_lesson, sample_user_signals
+    ):
+        """_generate_bullets_with_llm closes the session before awaiting the LLM"""
+        closed_before_llm = {}
+
+        async def fake_ainvoke(messages):
+            closed_before_llm["value"] = mock_db.close.called
+            response = Mock()
+            response.content = '{"personalized_bullets": ["Bullet 1", "Bullet 2"]}'
+            return response
+
+        with patch.object(primer_service, "_fetch_lesson_content", return_value=[]):
+            with patch.object(primer_service_module, "primers_model") as mock_model:
+                mock_model.ainvoke = fake_ainvoke
+                bullets = await primer_service._generate_bullets_with_llm(
+                    sample_lesson, sample_user_signals
+                )
+
+        assert closed_before_llm["value"] is True
+        assert bullets == ["Bullet 1", "Bullet 2"]
 
 
 # Integration Test: Full Generation Flow


### PR DESCRIPTION
## Purpose

Post-release Sentry triage found `/primers/personalized/stream` holding its pooled sync DB connection across the entire streaming LLM generation (tens of seconds). With the DEE-59 pool cap (`pool_size=2, max_overflow=1` per worker), 2-3 concurrent primer streams pin the whole sync pool, and every other sync route waits 30s then 500s.

Fixes **Sentry PYTHON-FASTAPI-2E / 2D / 2B** (`TimeoutError: QueuePool limit of size 2 overflow 1 reached`) — victims were `/hikmah-trees/{tree_id}` and `/hikmah/pages/{lesson_content_id}/quiz-submit`; also reduces pressure on the Supabase 15-client session-mode cap (PYTHON-FASTAPI-11/2A/10/1C).

## Change

`services/primer_service.py`: call `self.db.close()` after the last pre-generation DB read in both `_stream_bullets_with_llm` and `_generate_bullets_with_llm`, releasing the pooled connection before LLM work — the same rule DEE-59 applied to the hikmah quiz memory path (`services/hikmah_quiz_service.py`). The session transparently re-acquires a connection for the short `_cache_primer` write afterwards; `Depends(get_db)` teardown double-close is a no-op.

## Impacted endpoints

- `POST /primers/personalized/stream` (fix)
- `POST /primers/personalized` (fix, same mechanism on the non-streaming path)
- `/hikmah-trees/*`, `/hikmah/pages/*` and all other sync routes (beneficiaries — no code change)

## Migrations / env vars

None.

## Test evidence

- New `TestPoolReleaseBeforeLLM` (2 tests) proves the session is closed before the first LLM token is requested on both paths, and generation output is unchanged.
- `pytest tests/test_primer_service.py`: 26 passed, 5 failed — the 5 failures are **pre-existing on main/release** (verified via stash A/B run; stale tests drifted from the implementation, e.g. patching a removed `small_llm` attribute).
- Full suite `pytest tests -q`: 363 passed; the 17 failures reproduce identically without this change (12 are local timing-sensitive concurrency/perf tests + the 5 above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
