### PR TITLE
DEE-5 - Implement rate limits on API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ REDIS_KEY_PREFIX=dev:chat
 REDIS_TTL_SECONDS=12000
 REDIS_MAX_MESSAGES=30
 
+# === Chat abuse rate limits (required; set in .env only — not committed) ===
+CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS=
+CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS=
+CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS=
+CHAT_RATE_LIMIT_LONG_MAX_REQUESTS=
+
 # === Memory / Personalization ===
 # Embedding model used for user memory note vectors (dimension count for HuggingFace all-mpnet-base-v2)
 EMBEDDING_MODEL=sentence-transformers/all-mpnet-base-v2

--- a/api/chat.py
+++ b/api/chat.py
@@ -11,6 +11,7 @@ from core import pipeline
 from core import pipeline_langgraph
 from core.auth import auth
 from core.memory import make_history
+from core.rate_limit import enforce_chat_rate_limit
 from agents.config.agent_config import AgentConfig
 from services import chat_persistence_service
 import logging
@@ -35,7 +36,11 @@ def _require_user_id(credentials: JWTAuthorizationCredentials) -> str:
         raise HTTPException(status_code=403, detail="Invalid token: missing user identifier")
     return user_id
 
-@chat_router.post("/")
+# Abuse guard on the chat POST routes. Route-level dependencies resolve before
+# the endpoint's own parameters and in list order, so `auth` must be listed
+# first — it populates `request.state.user_id`, which the limiter keys on.
+# FastAPI caches it, so the JWT is still verified only once per request.
+@chat_router.post("/", dependencies=[Depends(auth), Depends(enforce_chat_rate_limit)])
 async def chat_pipeline_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),
@@ -64,7 +69,7 @@ async def chat_pipeline_ep(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@chat_router.post("/stream")
+@chat_router.post("/stream", dependencies=[Depends(auth), Depends(enforce_chat_rate_limit)])
 async def chat_pipeline_stream_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),
@@ -125,7 +130,10 @@ async def chat_pipeline_stream_ep(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@chat_router.post("/stream/agentic")
+@chat_router.post(
+    "/stream/agentic",
+    dependencies=[Depends(auth), Depends(enforce_chat_rate_limit)],
+)
 async def chat_pipeline_agentic_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),
@@ -251,7 +259,7 @@ async def chat_pipeline_agentic_ep(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@chat_router.post("/agentic")
+@chat_router.post("/agentic", dependencies=[Depends(auth), Depends(enforce_chat_rate_limit)])
 async def chat_pipeline_agentic_non_stream_ep(
     request: ChatRequest,
     credentials: JWTAuthorizationCredentials = Depends(auth),

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,7 +1,16 @@
+from typing import Optional
+
 import requests
+from starlette.requests import Request
+
 from core.config import SUPABASE_URL, ENV
 
-from models.JWTBearer import JWKS, JWTBearer, DevBypassBearer
+from models.JWTBearer import (
+    JWKS,
+    JWTBearer,
+    DevBypassBearer,
+    JWTAuthorizationCredentials,
+)
 
 jwks = JWKS.model_validate(
     requests.get(
@@ -9,6 +18,20 @@ jwks = JWKS.model_validate(
     ).json()
 )
 
+
+class UserScopedBearer(DevBypassBearer):
+    """Auth dependency that also publishes the caller's id on the request.
+
+    Dependencies that don't receive the credentials object — notably
+    `enforce_chat_rate_limit` — read `request.state.user_id`.
+    """
+
+    async def __call__(self, request: Request) -> Optional[JWTAuthorizationCredentials]:
+        credentials = await super().__call__(request)
+        request.state.user_id = credentials.claims.get("sub") if credentials else None
+        return credentials
+
+
 # Single auth dependency: dev bypass in development, strict in production.
 # Routes import only `auth` — optional_auth is no longer needed.
-auth = DevBypassBearer(jwks, env=ENV)
+auth = UserScopedBearer(jwks, env=ENV)

--- a/core/config.py
+++ b/core/config.py
@@ -29,6 +29,20 @@ KEY_PREFIX = os.getenv("REDIS_KEY_PREFIX", "dev:chat")
 # is a product decision, not a code one.
 TTL_SECONDS = int(os.getenv("REDIS_TTL_SECONDS", "12000"))
 MAX_MESSAGES = int(os.getenv("REDIS_MAX_MESSAGES", "30"))
+
+
+def _require_env_int(name: str) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        raise ValueError(f"Missing required env var: {name}")
+    return int(raw)
+
+
+# Chat abuse rate limits — thresholds are env-only (never hardcoded in app logic).
+CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS = _require_env_int("CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS")
+CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS = _require_env_int("CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS")
+CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS = _require_env_int("CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS")
+CHAT_RATE_LIMIT_LONG_MAX_REQUESTS = _require_env_int("CHAT_RATE_LIMIT_LONG_MAX_REQUESTS")
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 LARGE_LLM = os.getenv("LARGE_LLM", "claude-sonnet-4-6")

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -1,0 +1,79 @@
+"""Abuse rate limiting for the chat endpoints.
+
+Deliberately narrow in scope: this blocks scripted floods against the four
+chat POST routes. It is not general-purpose quota enforcement — per-user
+token/question budgets are out of scope.
+
+All Redis I/O reuses the shared async client from `core.memory`; this module
+never opens a connection of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import List, Tuple
+
+from fastapi import HTTPException, Request
+
+from core.memory import _get_async_redis
+
+logger = logging.getLogger(__name__)
+
+# (window_seconds, max_calls). A request is rejected if it exceeds any rule.
+CHAT_RATE_LIMIT_RULES: Tuple[Tuple[int, int], ...] = ((60, 20), (300, 50))
+
+# The limiter must never become the slowest part of a request.
+REDIS_TIMEOUT_SECONDS = 1.0
+
+
+def _rate_limit_key(request: Request) -> str:
+    """Per-user when authenticated, per-IP otherwise.
+
+    `request.state.user_id` is set by the auth dependency, which must resolve
+    before this one — see the route declarations in `api/chat.py`.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    if user_id:
+        return f"user:{user_id}"
+    client = request.client
+    return f"ip:{client.host if client else 'unknown'}"
+
+
+async def _incr_windows(key: str, now: int) -> List[int]:
+    """INCR + EXPIRE every rule's window in a single pipeline round-trip."""
+    client = _get_async_redis()
+    async with client.pipeline(transaction=False) as pipe:
+        for window, _limit in CHAT_RATE_LIMIT_RULES:
+            redis_key = f"ratelimit:chat:{key}:{window}:{now // window}"
+            await pipe.incr(redis_key)
+            await pipe.expire(redis_key, window)
+        results = await pipe.execute()
+    return [int(count) for count in results[::2]]
+
+
+async def enforce_chat_rate_limit(request: Request) -> None:
+    """FastAPI dependency: raise 429 when the caller exceeds any chat rule."""
+    key = _rate_limit_key(request)
+    now = int(time.time())
+
+    try:
+        counts = await asyncio.wait_for(_incr_windows(key, now), REDIS_TIMEOUT_SECONDS)
+    except Exception:
+        # Fail open: an unreachable or slow Redis must not take chat down.
+        logger.warning("chat rate limit skipped, redis unavailable", exc_info=True)
+        return
+
+    for count, (window, limit) in zip(counts, CHAT_RATE_LIMIT_RULES):
+        if count > limit:
+            retry_after = window - (now % window)
+            logger.warning(
+                "chat rate limit exceeded",
+                extra={"rate_limit_key": key, "window": window, "count": count},
+            )
+            raise HTTPException(
+                status_code=429,
+                detail=f"Too many chat requests. Limit is {limit} per {window} seconds.",
+                headers={"Retry-After": str(retry_after)},
+            )

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -17,15 +17,29 @@ from typing import List, Tuple
 
 from fastapi import HTTPException, Request
 
+from core.config import (
+    CHAT_RATE_LIMIT_LONG_MAX_REQUESTS,
+    CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS,
+    CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS,
+    CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS,
+)
 from core.memory import _get_async_redis
 
 logger = logging.getLogger(__name__)
 
-# (window_seconds, max_calls). A request is rejected if it exceeds any rule.
-CHAT_RATE_LIMIT_RULES: Tuple[Tuple[int, int], ...] = ((60, 20), (300, 50))
+# Public 429 copy — intentionally generic; never expose thresholds or timing.
+CHAT_RATE_LIMIT_MESSAGE = "Too many requests, please slow down."
 
 # The limiter must never become the slowest part of a request.
 REDIS_TIMEOUT_SECONDS = 1.0
+
+
+def chat_rate_limit_rules() -> Tuple[Tuple[int, int], ...]:
+    """Return (window_seconds, max_calls) rules from env-backed config."""
+    return (
+        (CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS, CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS),
+        (CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS, CHAT_RATE_LIMIT_LONG_MAX_REQUESTS),
+    )
 
 
 def _rate_limit_key(request: Request) -> str:
@@ -41,11 +55,11 @@ def _rate_limit_key(request: Request) -> str:
     return f"ip:{client.host if client else 'unknown'}"
 
 
-async def _incr_windows(key: str, now: int) -> List[int]:
+async def _incr_windows(key: str, now: int, rules: Tuple[Tuple[int, int], ...]) -> List[int]:
     """INCR + EXPIRE every rule's window in a single pipeline round-trip."""
     client = _get_async_redis()
     async with client.pipeline(transaction=False) as pipe:
-        for window, _limit in CHAT_RATE_LIMIT_RULES:
+        for window, _limit in rules:
             redis_key = f"ratelimit:chat:{key}:{window}:{now // window}"
             await pipe.incr(redis_key)
             await pipe.expire(redis_key, window)
@@ -55,25 +69,31 @@ async def _incr_windows(key: str, now: int) -> List[int]:
 
 async def enforce_chat_rate_limit(request: Request) -> None:
     """FastAPI dependency: raise 429 when the caller exceeds any chat rule."""
+    rules = chat_rate_limit_rules()
     key = _rate_limit_key(request)
     now = int(time.time())
 
     try:
-        counts = await asyncio.wait_for(_incr_windows(key, now), REDIS_TIMEOUT_SECONDS)
+        counts = await asyncio.wait_for(
+            _incr_windows(key, now, rules),
+            REDIS_TIMEOUT_SECONDS,
+        )
     except Exception:
         # Fail open: an unreachable or slow Redis must not take chat down.
         logger.warning("chat rate limit skipped, redis unavailable", exc_info=True)
         return
 
-    for count, (window, limit) in zip(counts, CHAT_RATE_LIMIT_RULES):
+    user_id = getattr(request.state, "user_id", None)
+    for count, (window, limit) in zip(counts, rules):
         if count > limit:
-            retry_after = window - (now % window)
             logger.warning(
                 "chat rate limit exceeded",
-                extra={"rate_limit_key": key, "window": window, "count": count},
+                extra={
+                    "user_id": user_id,
+                    "rate_limit_key": key,
+                    "window_seconds": window,
+                    "limit": limit,
+                    "count": count,
+                },
             )
-            raise HTTPException(
-                status_code=429,
-                detail=f"Too many chat requests. Limit is {limit} per {window} seconds.",
-                headers={"Retry-After": str(retry_after)},
-            )
+            raise HTTPException(status_code=429, detail=CHAT_RATE_LIMIT_MESSAGE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ _TEST_ENV_DEFAULTS = {
     # Switch to fakeredis:// in Phase 4 once the async wrapper lands.
     "REDIS_URL": "redis://127.0.0.1:1/0",
     "REDIS_KEY_PREFIX": "test:chat",
+    "CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS": "60",
+    "CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS": "10",
+    "CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS": "300",
+    "CHAT_RATE_LIMIT_LONG_MAX_REQUESTS": "30",
     "ENV": "test",
     # db/config.py instantiates pydantic Settings() at import. The fields are
     # required, so provide test-only placeholders. No real DB is touched —

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -4,11 +4,9 @@ The limiter is a fixed-window counter, so these tests drive a fake clock
 rather than sleeping. Redis is `fakeredis.aioredis`, so the whole suite runs
 in-process with no daemon.
 
+Thresholds come from env via `core.config` (see `tests/conftest.py` defaults).
 The test app mirrors the real wiring in `api/chat.py`: auth first in the
-route-level dependency list, then the limiter. That ordering is load-bearing
-— it is what makes `request.state.user_id` available for per-user keying —
-so `test_limit_is_keyed_per_user` and `test_key_is_scoped_to_the_user_id`
-exist to catch a regression if someone reorders them.
+route-level dependency list, then the limiter.
 """
 
 from __future__ import annotations
@@ -19,7 +17,13 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from core import rate_limit as rate_limit_mod
-from core.rate_limit import enforce_chat_rate_limit
+from core.config import (
+    CHAT_RATE_LIMIT_LONG_MAX_REQUESTS,
+    CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS,
+    CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS,
+    CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS,
+)
+from core.rate_limit import CHAT_RATE_LIMIT_MESSAGE, enforce_chat_rate_limit
 
 
 class _FakeClock:
@@ -37,9 +41,8 @@ class _FakeClock:
 
 @pytest.fixture
 def clock(monkeypatch) -> _FakeClock:
-    # Start on a 300s boundary so a test can fill the long window without
-    # accidentally straddling two buckets.
-    fake = _FakeClock(300 * 1_000_000)
+    # Start on a long-window boundary so multi-bucket tests stay in one bucket.
+    fake = _FakeClock(CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS * 1_000_000)
     monkeypatch.setattr(rate_limit_mod, "time", fake)
     return fake
 
@@ -73,58 +76,63 @@ def _post(client: TestClient, user: str = "user-a"):
     return client.post("/chat/stream/agentic", headers={"x-test-user": user})
 
 
-def test_twenty_first_call_in_a_minute_is_rejected(client):
-    for i in range(20):
+def _assert_generic_429(response) -> None:
+    assert response.status_code == 429
+    assert response.json()["detail"] == CHAT_RATE_LIMIT_MESSAGE
+    assert "Retry-After" not in response.headers
+
+
+def test_short_window_limit_is_rejected(client):
+    short_max = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS
+    for i in range(short_max):
         assert _post(client).status_code == 200, f"call {i + 1} should have passed"
 
-    blocked = _post(client)
-    assert blocked.status_code == 429
-    assert "20 per 60 seconds" in blocked.json()["detail"]
-    assert blocked.headers["Retry-After"] == "60"
+    _assert_generic_429(_post(client))
 
 
 def test_short_window_resets_on_the_next_bucket(client, clock):
-    for _ in range(20):
+    short_max = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS
+    for _ in range(short_max):
         assert _post(client).status_code == 200
-    assert _post(client).status_code == 429
+    _assert_generic_429(_post(client))
 
-    clock.advance(60)
+    clock.advance(CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS)
     assert _post(client).status_code == 200
 
 
-def test_fifty_first_call_in_five_minutes_is_rejected(client, clock):
-    """Stay under the 60s rule (15 calls per minute) so only the 300s rule
-    can trip. 15 calls in each of four sub-windows crosses 50 on call 51."""
+def test_long_window_limit_is_rejected(client, clock):
+    """Stay under the short-window rule each minute so only the long rule trips."""
+    short_max = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS
+    long_max = CHAT_RATE_LIMIT_LONG_MAX_REQUESTS
+    calls_per_minute = short_max - 1
+
     calls = 0
-    for _ in range(3):
-        for _ in range(15):
+    while calls < long_max:
+        batch = min(calls_per_minute, long_max - calls)
+        for _ in range(batch):
             calls += 1
             assert _post(client).status_code == 200, f"call {calls} should have passed"
-        clock.advance(61)
+        if calls < long_max:
+            clock.advance(CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS + 1)
 
-    # 45 calls so far, all inside the same 300s bucket. Five more to reach 50.
-    for _ in range(5):
-        calls += 1
-        assert _post(client).status_code == 200, f"call {calls} should have passed"
-
-    blocked = _post(client)
-    assert blocked.status_code == 429
-    assert "50 per 300 seconds" in blocked.json()["detail"]
+    _assert_generic_429(_post(client))
 
 
 def test_limit_is_keyed_per_user(client):
-    for _ in range(20):
+    short_max = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS
+    for _ in range(short_max):
         assert _post(client, user="user-a").status_code == 200
-    assert _post(client, user="user-a").status_code == 429
+    _assert_generic_429(_post(client, user="user-a"))
 
     # A different caller must not inherit user-a's exhausted budget.
     assert _post(client, user="user-b").status_code == 200
 
 
 def test_falls_back_to_client_ip_when_unauthenticated(client):
-    for _ in range(20):
+    short_max = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS
+    for _ in range(short_max):
         assert client.post("/chat/stream/agentic").status_code == 200
-    assert client.post("/chat/stream/agentic").status_code == 429
+    _assert_generic_429(client.post("/chat/stream/agentic"))
 
 
 @pytest.mark.asyncio
@@ -134,8 +142,11 @@ async def test_key_is_scoped_to_the_user_id(client, fake_redis, clock):
     _post(client, user="user-a")
 
     keys = {key.decode() for key in await fake_redis.keys("*")}
-    bucket = int(clock.time()) // 60
-    assert f"ratelimit:chat:user:user-a:60:{bucket}" in keys
+    bucket = int(clock.time()) // CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS
+    assert (
+        f"ratelimit:chat:user:user-a:{CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS}:{bucket}"
+        in keys
+    )
 
 
 def test_fails_open_when_redis_is_unavailable(client, monkeypatch):
@@ -146,5 +157,6 @@ def test_fails_open_when_redis_is_unavailable(client, monkeypatch):
 
     monkeypatch.setattr(rate_limit_mod, "_get_async_redis", exploding_client)
 
-    for _ in range(25):
+    over_limit = CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS + 5
+    for _ in range(over_limit):
         assert _post(client).status_code == 200

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,150 @@
+"""Tests for the chat abuse rate limiter (`core/rate_limit.py`).
+
+The limiter is a fixed-window counter, so these tests drive a fake clock
+rather than sleeping. Redis is `fakeredis.aioredis`, so the whole suite runs
+in-process with no daemon.
+
+The test app mirrors the real wiring in `api/chat.py`: auth first in the
+route-level dependency list, then the limiter. That ordering is load-bearing
+— it is what makes `request.state.user_id` available for per-user keying —
+so `test_limit_is_keyed_per_user` and `test_key_is_scoped_to_the_user_id`
+exist to catch a regression if someone reorders them.
+"""
+
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from core import rate_limit as rate_limit_mod
+from core.rate_limit import enforce_chat_rate_limit
+
+
+class _FakeClock:
+    """Stands in for the `time` module inside `core.rate_limit`."""
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch) -> _FakeClock:
+    # Start on a 300s boundary so a test can fill the long window without
+    # accidentally straddling two buckets.
+    fake = _FakeClock(300 * 1_000_000)
+    monkeypatch.setattr(rate_limit_mod, "time", fake)
+    return fake
+
+
+@pytest.fixture
+def fake_redis(monkeypatch) -> fakeredis.aioredis.FakeRedis:
+    client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(rate_limit_mod, "_get_async_redis", lambda: client)
+    return client
+
+
+@pytest.fixture
+def client(clock, fake_redis) -> TestClient:
+    app = FastAPI()
+
+    async def stub_auth(request: Request) -> None:
+        """Stand-in for `core.auth.auth`, which sets the same attribute."""
+        request.state.user_id = request.headers.get("x-test-user")
+
+    @app.post(
+        "/chat/stream/agentic",
+        dependencies=[Depends(stub_auth), Depends(enforce_chat_rate_limit)],
+    )
+    async def chat() -> dict:
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def _post(client: TestClient, user: str = "user-a"):
+    return client.post("/chat/stream/agentic", headers={"x-test-user": user})
+
+
+def test_twenty_first_call_in_a_minute_is_rejected(client):
+    for i in range(20):
+        assert _post(client).status_code == 200, f"call {i + 1} should have passed"
+
+    blocked = _post(client)
+    assert blocked.status_code == 429
+    assert "20 per 60 seconds" in blocked.json()["detail"]
+    assert blocked.headers["Retry-After"] == "60"
+
+
+def test_short_window_resets_on_the_next_bucket(client, clock):
+    for _ in range(20):
+        assert _post(client).status_code == 200
+    assert _post(client).status_code == 429
+
+    clock.advance(60)
+    assert _post(client).status_code == 200
+
+
+def test_fifty_first_call_in_five_minutes_is_rejected(client, clock):
+    """Stay under the 60s rule (15 calls per minute) so only the 300s rule
+    can trip. 15 calls in each of four sub-windows crosses 50 on call 51."""
+    calls = 0
+    for _ in range(3):
+        for _ in range(15):
+            calls += 1
+            assert _post(client).status_code == 200, f"call {calls} should have passed"
+        clock.advance(61)
+
+    # 45 calls so far, all inside the same 300s bucket. Five more to reach 50.
+    for _ in range(5):
+        calls += 1
+        assert _post(client).status_code == 200, f"call {calls} should have passed"
+
+    blocked = _post(client)
+    assert blocked.status_code == 429
+    assert "50 per 300 seconds" in blocked.json()["detail"]
+
+
+def test_limit_is_keyed_per_user(client):
+    for _ in range(20):
+        assert _post(client, user="user-a").status_code == 200
+    assert _post(client, user="user-a").status_code == 429
+
+    # A different caller must not inherit user-a's exhausted budget.
+    assert _post(client, user="user-b").status_code == 200
+
+
+def test_falls_back_to_client_ip_when_unauthenticated(client):
+    for _ in range(20):
+        assert client.post("/chat/stream/agentic").status_code == 200
+    assert client.post("/chat/stream/agentic").status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_key_is_scoped_to_the_user_id(client, fake_redis, clock):
+    """Guards the dependency ordering: if the limiter ran before auth,
+    `request.state.user_id` would be unset and the key would be IP-scoped."""
+    _post(client, user="user-a")
+
+    keys = {key.decode() for key in await fake_redis.keys("*")}
+    bucket = int(clock.time()) // 60
+    assert f"ratelimit:chat:user:user-a:60:{bucket}" in keys
+
+
+def test_fails_open_when_redis_is_unavailable(client, monkeypatch):
+    """Availability beats perfect blocking: a broken Redis must not 500 chat."""
+
+    def exploding_client():
+        raise ConnectionError("redis is down")
+
+    monkeypatch.setattr(rate_limit_mod, "_get_async_redis", exploding_client)
+
+    for _ in range(25):
+        assert _post(client).status_code == 200


### PR DESCRIPTION
<h1>Add rate limiting to chat endpoints</h1>
<h2>What this does</h2>
<p>Right now, nothing stops a single person (or a script) from hammering our chat endpoints as fast as they can. Every chat call costs us money in LLM tokens and Pinecone queries, and a burst of them can slow the service down for everyone else. This PR adds a guard that cuts off callers who are clearly abusing the API.</p>
<p>A caller is blocked with <strong>HTTP 429 (Too Many Requests)</strong> if they exceed the configured request thresholds. Both a short-window and a long-window rule are checked on every chat call; tripping either one blocks the request. The blocked response is intentionally generic — callers see a simple "please slow down" message with no limit numbers, window durations, or <code>Retry-After</code> header. Full breach detail (user id, which rule tripped, the counts) is recorded in server-side logs only.</p>
<p>Thresholds live in environment variables, not in committed code, so limits can be tuned per environment without a deploy and are never exposed to clients.</p>
<p>To be clear about scope: <strong>this is an abuse blocker, not a usage quota.</strong> The limits are set far above what a real person clicking through the app would ever hit — a normal user will never see a 429. Per-user token or question budgets are a separate piece of work and are explicitly not part of this.</p>
<h2>Which endpoints are affected</h2>
<p>Only the four chat POST routes, since those are the expensive ones:</p>
<ul>
<li><code>POST /chat/</code></li>
<li><code>POST /chat/stream</code></li>
<li><code>POST /chat/stream/agentic</code></li>
<li><code>POST /chat/agentic</code></li>
</ul>
<p>Deliberately <strong>not</strong> limited: <code>GET /chat/saved</code>, <code>GET /chat/saved/{session_id}</code>, and <code>DELETE /chat/session/{session_id}</code>. These are cheap reads and a session reset — limiting them would only annoy legitimate users.</p>
<h2>How it works</h2>
<p>Each caller gets a counter in Redis per time window. The counter key includes the window it belongs to, so when a new window starts, a fresh counter starts with it and the old one expires on its own. Each request increments the counters and checks them against the configured limits.</p>
<p>Two implementation constraints from the codebase owner, both honored:</p>
<ul>
<li><strong>All Redis work is async and reuses the existing shared connection</strong> from <code>core/memory.py</code>. No new connection pool is opened. Both windows' increment and expiry commands are batched into a single pipeline, so the whole check costs one network round-trip to Redis.</li>
<li><strong><code>slowapi</code> was not used.</strong> It's the obvious off-the-shelf choice, but its Redis calls are synchronous, which would block the event loop and undo the async work done in DEE-36 on the streaming path.</li>
</ul>
<p>Callers are identified by their user ID from the JWT (<code>sub</code> claim), so limits are per-account rather than shared across everyone behind the same IP. If there's no authenticated user, it falls back to the client IP address.</p>
<p>Thresholds are read from four required environment variables in <code>core/config.py</code>:</p>
<ul>
<li><code>CHAT_RATE_LIMIT_SHORT_WINDOW_SECONDS</code></li>
<li><code>CHAT_RATE_LIMIT_SHORT_MAX_REQUESTS</code></li>
<li><code>CHAT_RATE_LIMIT_LONG_WINDOW_SECONDS</code></li>
<li><code>CHAT_RATE_LIMIT_LONG_MAX_REQUESTS</code></li>
</ul>
<p>Var names are listed in <code>.env.example</code> (no values committed). Actual values are set in <code>.env</code> per environment. The app fails fast at startup if any are missing.</p>
<h2>A bug in the ticket, and the fix</h2>
<p>The ticket specified adding the limiter to each route like this:</p>
<pre><code class="language-python">dependencies=[Depends(enforce_chat_rate_limit)]
</code></pre>
<p>Written that way, it would have appeared to work but silently done the wrong thing. FastAPI runs route-level dependencies <em>before</em> the ones declared in the endpoint's own function signature — and the JWT check lives in the signature. So the rate limiter would have run before the user was identified, found no user ID, and fallen back to keying by IP for <strong>every single request</strong>. Since our traffic arrives through a Caddy reverse proxy, that could collapse into something close to one shared global limit for all users. There'd be no error or warning — just quietly incorrect behavior.</p>
<p>The fix is to list the auth dependency first on the same line, so it resolves before the limiter:</p>
<pre><code class="language-python">dependencies=[Depends(auth), Depends(enforce_chat_rate_limit)]
</code></pre>
<p>Route-level dependencies resolve in the order they're listed. FastAPI caches each dependency within a request, so even though <code>auth</code> now appears in two places on these routes, <strong>the JWT is still verified exactly once</strong> — no extra work per request. I verified this by inspecting the dependency tree FastAPI builds: <code>auth</code> appears twice with identical cache keys, and resolves first.</p>
<h2>Deliberate tradeoffs</h2>
<p><strong>Fixed windows.</strong> The limiter uses a fixed-window counter, which trades a small amount of precision at window edges for much lower Redis cost per request. Since the goal is stopping sustained abuse rather than enforcing precise fairness, that's an acceptable tradeoff.</p>
<p><strong>Generic 429 responses.</strong> Blocked callers see only "Too many requests, please slow down." — no limit numbers, no window durations, no <code>Retry-After</code> header. Exposing thresholds in the response would give a caller information about how to pace around them. Operators still get full context in server-side logs (user id, window, limit, count).</p>
<p><strong>Thresholds in env, not code.</strong> Limits can be tuned per environment without a code change or redeploy. The tradeoff is that all four vars must be set before the server starts — missing values fail fast rather than falling back to silent defaults.</p>
<p><strong>Availability vs strict enforcement (for reviewers).</strong> If Redis is unavailable, the limiter currently allows the request through and logs a warning, with a short timeout capping any added latency — prioritizing chat availability over strict enforcement, consistent with how Redis is treated elsewhere in the app. This is a deliberate judgment call; happy to switch to stricter behavior if the team prefers. <strong>Opinions welcome.</strong></p>
<h2>Changes</h2>

File | What changed
-- | --
core/rate_limit.py | New. The enforce_chat_rate_limit dependency, generic 429 message, and Redis pipeline logic.
core/config.py | Reads the four chat rate-limit env vars (required, no hardcoded defaults).
core/auth.py | The auth dependency now also records the caller's user ID on request.state.user_id, so the limiter can read it without needing the credentials object.
api/chat.py | Added the guard to the four POST routes. No handler logic touched.
tests/test_rate_limit.py | New. 7 tests.
.env.example | Lists the four rate-limit var names (no values).


<ul>
<li><strong>No new dependencies</strong> — <code>redis</code> and <code>fakeredis</code> were already in <code>requirements.txt</code>.</li>
<li><strong>No database migrations.</strong></li>
<li><strong>Four new required environment variables</strong> (see above). Set actual values in <code>.env</code> only — not committed.</li>
</ul>
<h2>Testing</h2>
<p><strong>Unit tests</strong> (<code>tests/test_rate_limit.py</code>, 7 passing). They use <code>fakeredis</code> and a fake clock, so they run in a fraction of a second with no real Redis and no <code>sleep()</code> calls. Thresholds come from env via <code>tests/conftest.py</code> defaults:</p>
<ul>
<li>exceeding the short-window limit is rejected with the generic 429 message</li>
<li>the counter resets once the next short window starts</li>
<li>exceeding the long-window limit is rejected</li>
<li>two different users don't share a budget</li>
<li>unauthenticated callers fall back to IP-based limiting</li>
<li>an unavailable Redis is handled gracefully instead of returning 500</li>
<li>the Redis key is user-scoped — guards against the dependency-ordering bug described above</li>
</ul>
<p>No test asserts on limit numbers or timing in the response body or headers.</p>
<p><strong>Manual end-to-end check</strong> against a locally running server with real Redis: repeated requests to <code>/chat/agentic</code> until blocked. Confirmed 429 with the generic message (no <code>Retry-After</code>), and user-scoped counters in Redis with correct expiry times.</p>
<p><strong>Full suite:</strong> pre-existing failures reproduce on a clean checkout of <code>main</code> and are unrelated to this change.</p>
<h2>Notes</h2>
<ul>
<li><strong>Follow-up (separate):</strong> alerting when the longer window is tripped.</li>
</ul>